### PR TITLE
Dummy user

### DIFF
--- a/scorep/__main__.py
+++ b/scorep/__main__.py
@@ -1,20 +1,10 @@
 import os
 import sys
 import importlib
-import getopt
 
 import scorep.trace
 import scorep.helper
 import scorep.subsystem
-
-
-def _usage(outfile):
-    outfile.write("""TODO
-""" % sys.argv[0])
-
-
-cuda_support = None
-opencl_support = None
 
 
 def _err_exit(msg):

--- a/scorep/subsystem.py
+++ b/scorep/subsystem.py
@@ -1,10 +1,5 @@
 import os
-import subprocess
-import re
 import sys
-import stat
-import platform
-import functools
 import distutils.ccompiler
 import tempfile
 import shutil

--- a/scorep/trace.py
+++ b/scorep/trace.py
@@ -2,6 +2,7 @@ __all__ = ['ScorepTrace']
 import sys
 import inspect
 import os.path
+import scorep.trace_dummy
 
 try:
     import threading
@@ -20,7 +21,7 @@ else:
         sys.settrace(None)
         threading.settrace(None)
 
-global_trace = None
+global_trace = scorep.trace_dummy.ScorepTraceDummy()
 
 
 class ScorepTrace:

--- a/scorep/trace.py
+++ b/scorep/trace.py
@@ -34,11 +34,10 @@ class ScorepTrace:
         global_trace = self
 
         self.pathtobasename = {}  # for memoizing os.path.basename
-        self.trace = trace
         self.scorep_bindings = scorep_bindings
         self.globaltrace = self.globaltrace_lt
         self.localtrace = self.localtrace_trace
-        self.no_init_trace = trace
+        self.no_init_trace = not trace
 
     def register(self):
         _settrace(self.globaltrace)
@@ -91,7 +90,7 @@ class ScorepTrace:
             else:
                 full_file_name = "None"
             line_number = frame.f_lineno
-            if self.trace and not code.co_name == "_unsettrace" and not modulename == "scorep.trace":
+            if not code.co_name == "_unsettrace" and not modulename == "scorep.trace":
                 self.scorep_bindings.region_begin(
                     modulename, code.co_name, full_file_name, line_number)
             return self.localtrace
@@ -104,8 +103,7 @@ class ScorepTrace:
             modulename = frame.f_globals.get('__name__', None)
             if modulename is None:
                 modulename = "None"
-            if self.trace:
-                self.scorep_bindings.region_end(modulename, code.co_name)
+            self.scorep_bindings.region_end(modulename, code.co_name)
         return self.localtrace
 
     def user_region_begin(self, name, file_name=None, line_number=None):

--- a/scorep/trace_dummy.py
+++ b/scorep/trace_dummy.py
@@ -1,0 +1,51 @@
+class ScorepTraceDummy:
+    def __init__(self, scorep_bindings=None, trace=True):
+        pass
+
+    def register(self):
+        pass
+
+    def unregister(self):
+        pass
+
+    def run(self, cmd):
+        pass
+
+    def runctx(self, cmd, globals=None, locals=None):
+        pass
+
+    def runfunc(self, func, *args, **kw):
+        pass
+
+    def user_region_begin(self, name, file_name=None, line_number=None):
+        pass
+
+    def user_region_end(self, name):
+        pass
+
+    def rewind_begin(self, name, file_name=None, line_number=None):
+        pass
+
+    def rewind_end(self, name, value):
+        pass
+
+    def oa_region_begin(self, name, file_name=None, line_number=None):
+        pass
+
+    def oa_region_end(self, name):
+        pass
+
+    def user_enable_recording(self):
+        pass
+
+    def user_disable_recording(self):
+        pass
+
+    def user_parameter_int(self, name, val):
+        pass
+
+    def user_parameter_uint(self, name, val):
+        pass
+
+    def user_parameter_string(self, name, string):
+        pass

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,23 @@
 from distutils.core import setup, Extension
 import scorep.helper
-
-(include, lib, lib_dir, macro, linker_flags) = scorep.helper.generate_compile_deps()
-
+import os
+import logging
 
 cmodules = []
-cmodules.append(Extension('scorep.scorep_bindings',
-                          include_dirs=include,
-                          libraries=[],
-                          extra_compile_args=["-std=c++11"],
-                          sources=['src/scorep.cpp']))
+no_scorep = False
+
+# This is not documented on purpose. Only use if you know what you are doing.
+if "SCOREP_NO_SCOREP" in os.environ and os.environ["SCOREP_NO_SCOREP"] == "YES":
+    logging.warning("building without Score-P! Tracing will not work!")
+    no_scorep = True
+
+if not no_scorep:
+    (include, _, _, _, _) = scorep.helper.generate_compile_deps()
+    cmodules.append(Extension('scorep.scorep_bindings',
+                              include_dirs=include,
+                              libraries=[],
+                              extra_compile_args=["-std=c++11"],
+                              sources=['src/scorep.cpp']))
 
 
 setup(

--- a/test/test.py
+++ b/test/test.py
@@ -86,6 +86,19 @@ class TestScorepBindingsPython(unittest.TestCase):
         self.assertRegex(std_out,
                          'LEAVE[ ]*[0-9 ]*[0-9 ]*Region: "user:test_region"')
 
+    def test_user_regions_no_scorep(self):
+        env = self.env
+        env["SCOREP_EXPERIMENT_DIRECTORY"] += "/test_user_regions_no_scorep"
+
+        out = call([self.python,
+                    "test_user_regions.py"],
+                   env=env)
+        std_out = out[1]
+        std_err = out[2]
+
+        self.assertEqual(std_err, self.expected_std_err)
+        self.assertEqual(std_out, "hello world\n")
+
     def test_user_rewind(self):
         env = self.env
         env["SCOREP_EXPERIMENT_DIRECTORY"] += "/test_user_rewind"
@@ -217,10 +230,10 @@ class TestScorepBindingsPython(unittest.TestCase):
         self.assertRegex(std_err, expected_std_err)
         self.assertEqual(std_out, expected_std_out)
 
-    def tearDown(self):
-        shutil.rmtree(
-            self.env["SCOREP_EXPERIMENT_DIRECTORY"],
-            ignore_errors=True)
+#     def tearDown(self):
+#         shutil.rmtree(
+#             self.env["SCOREP_EXPERIMENT_DIRECTORY"],
+#             ignore_errors=True)
 
 
 if __name__ == '__main__':

--- a/test/test.py
+++ b/test/test.py
@@ -230,10 +230,10 @@ class TestScorepBindingsPython(unittest.TestCase):
         self.assertRegex(std_err, expected_std_err)
         self.assertEqual(std_out, expected_std_out)
 
-#     def tearDown(self):
-#         shutil.rmtree(
-#             self.env["SCOREP_EXPERIMENT_DIRECTORY"],
-#             ignore_errors=True)
+    def tearDown(self):
+        shutil.rmtree(
+            self.env["SCOREP_EXPERIMENT_DIRECTORY"],
+            ignore_errors=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Clarify the use of ScorepTrace(..., trace=False), and add a dummy user instrumentation, which is loaded by default.
Fixes #35 .