### PR TITLE
Issue 46

### DIFF
--- a/scorep/helper.py
+++ b/scorep/helper.py
@@ -52,19 +52,6 @@ def add_to_ld_library_path(path):
                 ":" + os.environ["LD_LIBRARY_PATH"]
 
 
-def generate_ld_preload(scorep_config):
-    """
-    This functions generate a string that needs to be passed to $LD_PRELOAD.
-    After this sting is passed, the tracing needs to be restarted with this $LD_PRELOAD in env.
-
-    @return ld_preload string which needs to be passed to LD_PRELOAD
-    """
-
-    (_, preload, _) = call(["scorep-config"] +
-                           scorep_config + ["--user", "--preload-libs"])
-    return preload
-
-
 def generate_compile_deps(config=[]):
     """
     Generates the data needed for compilation.

--- a/scorep/subsystem.py
+++ b/scorep/subsystem.py
@@ -7,13 +7,26 @@ import shutil
 import scorep.helper
 
 
-def gen_subsystem_lib_name():
+def generate_subsystem_lib_name():
     """
     generate the name for the subsystem lib.
     """
     mpi_lib_name = "libscorep_init_subsystem-{}.so".format(
         scorep.helper.get_python_version())
     return mpi_lib_name
+
+
+def generate_ld_preload(scorep_config):
+    """
+    This functions generate a string that needs to be passed to $LD_PRELOAD.
+    After this sting is passed, the tracing needs to be restarted with this $LD_PRELOAD in env.
+
+    @return ld_preload string which needs to be passed to LD_PRELOAD
+    """
+
+    (_, preload, _) = scorep.helper.call(
+        ["scorep-config"] + scorep_config + ["--user", "--preload-libs"])
+    return preload
 
 
 def generate_subsystem_code(config=[]):
@@ -62,7 +75,7 @@ def generate(scorep_config, keep_files=False):
     with open(temp_dir + "/scorep_init.c", "w") as f:
         f.write(scorep_adapter_init)
 
-    subsystem_lib_name = gen_subsystem_lib_name()
+    subsystem_lib_name = generate_subsystem_lib_name()
 
     cc = distutils.ccompiler.new_compiler()
     compiled_subsystem = cc.compile(
@@ -97,7 +110,7 @@ def init_environment(scorep_config=[], keep_files=False):
 
     subsystem_lib_name, temp_dir = scorep.subsystem.generate(
         scorep_config, keep_files)
-    scorep_ld_preload = scorep.helper.generate_ld_preload(scorep_config)
+    scorep_ld_preload = generate_ld_preload(scorep_config)
 
     scorep.helper.add_to_ld_library_path(temp_dir)
 

--- a/scorep/subsystem.py
+++ b/scorep/subsystem.py
@@ -58,6 +58,13 @@ def generate(scorep_config, keep_files=False):
     (include, lib, lib_dir, macro,
      linker_flags_tmp) = scorep.helper.generate_compile_deps(scorep_config)
     scorep_adapter_init = generate_subsystem_code(scorep_config)
+    if ("-lscorep_adapter_opari2_mgmt" in lib):
+        scorep_adapter_init += "\n"
+        scorep_adapter_init += "/* OPARI dependencies */\n"
+        scorep_adapter_init += "void POMP2_Init_regions(){}\n"
+        scorep_adapter_init += "size_t POMP2_Get_num_regions(){return 0;};\n"
+        scorep_adapter_init += "void POMP2_USER_Init_regions(){};\n"
+        scorep_adapter_init += "size_t POMP2_USER_Get_num_regions(){return 0;};\n"
 
     # add -Wl,-no-as-needed to tell the compiler that we really want to link these. Actually this sould be default.
     # as distutils adds extra args at the very end we need to add all the libs


### PR DESCRIPTION
Fixes #46 .
OPARI defines his own `.opari2_init.c`. Unfortunately, it does not allow an as easy usage as `scorep-config`. However, adding the required definitions manually seems to work. 