### PR TITLE
Fix extracing Score-P version.

### DIFF
--- a/scorep/helper.py
+++ b/scorep/helper.py
@@ -40,7 +40,11 @@ def get_scorep_version():
     (return_code, std_out, std_err) = call(["scorep", "--version"])
     if (return_code != 0):
         raise RuntimeError("Cannot call Score-P, reason {}".format(std_err))
-    version = float(std_out.lstrip("Score-P"))
+    try:
+        m = re.search(r"\d+\.\d+|\d+", std_out)
+        version = float(m.group())
+    except:
+        raise RuntimeError("Score-P version string is not supported")
     return version
 
 


### PR DESCRIPTION
Actually, `scorep.helper.get_scorep_version` raise an exception while extracting the version number of a Score-P development version. This request fixes the operation.

Closes #60 