### PR TITLE
Annotate random region exits.

### DIFF
--- a/src/scorep.cpp
+++ b/src/scorep.cpp
@@ -31,15 +31,35 @@ void region_begin(const std::string& region_name, std::string module, std::strin
         SCOREP_User_RegionInit(&handle.value, NULL, &SCOREP_User_LastFileHandle,
                                region_name.c_str(), SCOREP_USER_REGION_TYPE_FUNCTION,
                                file_name.c_str(), line_number);
-        SCOREP_User_RegionSetGroup(handle.value, std::string(module,0,module.find('.')).c_str());
+        SCOREP_User_RegionSetGroup(handle.value, std::string(module, 0, module.find('.')).c_str());
     }
     SCOREP_User_RegionEnter(handle.value);
 }
 
 void region_end(const std::string& region_name)
 {
-    auto& handle = regions.at(region_name);
-    SCOREP_User_RegionEnd(handle.value);
+    try
+    {
+        auto& handle = regions.at(region_name);
+        SCOREP_User_RegionEnd(handle.value);
+    }
+    catch (std::out_of_range& e)
+    {
+        static region_handle error_region;
+        if (error_region.value == SCOREP_USER_INVALID_REGION)
+        {
+            SCOREP_User_RegionInit(&error_region.value, NULL, &SCOREP_User_LastFileHandle,
+                                   "error_region", SCOREP_USER_REGION_TYPE_FUNCTION, "scorep.cpp",
+                                   0);
+            SCOREP_User_RegionSetGroup(error_region.value, "error");
+        }
+        SCOREP_User_RegionEnter(error_region.value);
+
+        SCOREP_User_ParameterHandle scorep_param = SCOREP_USER_INVALID_PARAMETER;
+        SCOREP_User_ParameterString(&scorep_param, "leave-region", region_name.c_str());
+
+        SCOREP_User_RegionEnd(error_region.value);
+    }
 }
 
 void rewind_begin(std::string region_name, std::string file_name, std::uint64_t line_number)

--- a/src/scorep.cpp
+++ b/src/scorep.cpp
@@ -46,6 +46,9 @@ void region_end(const std::string& region_name)
     catch (std::out_of_range& e)
     {
         static region_handle error_region;
+        static SCOREP_User_ParameterHandle scorep_param = SCOREP_USER_INVALID_PARAMETER;
+        static bool error_printed = false;
+
         if (error_region.value == SCOREP_USER_INVALID_REGION)
         {
             SCOREP_User_RegionInit(&error_region.value, NULL, &SCOREP_User_LastFileHandle,
@@ -54,11 +57,17 @@ void region_end(const std::string& region_name)
             SCOREP_User_RegionSetGroup(error_region.value, "error");
         }
         SCOREP_User_RegionEnter(error_region.value);
-
-        SCOREP_User_ParameterHandle scorep_param = SCOREP_USER_INVALID_PARAMETER;
         SCOREP_User_ParameterString(&scorep_param, "leave-region", region_name.c_str());
-
         SCOREP_User_RegionEnd(error_region.value);
+
+        if (!error_printed)
+        {
+            std::cerr << "SCOREP_BINDING_PYTHON ERROR: There was a region exit without an enter!\n"
+                      << "SCOREP_BINDING_PYTHON ERROR: For details look for \"error_region\" in "
+                         "the trace or profile."
+                      << std::endl;
+            error_printed = true;
+        }
     }
 }
 

--- a/test/test.py
+++ b/test/test.py
@@ -224,7 +224,6 @@ class TestScorepBindingsPython(unittest.TestCase):
         self.assertRegex(std_out,
                          'LEAVE[ ]*[0-9 ]*[0-9 ]*Region: "__main__:foo"')
 
-
     def test_user_instrumentation(self):
         env = self.env
         env["SCOREP_EXPERIMENT_DIRECTORY"] += "/test_user_instrumentation"
@@ -252,6 +251,45 @@ class TestScorepBindingsPython(unittest.TestCase):
                          'ENTER[ ]*[0-9 ]*[0-9 ]*Region: "__main__:foo"')
         self.assertRegex(std_out,
                          'LEAVE[ ]*[0-9 ]*[0-9 ]*Region: "__main__:foo"')
+
+    def test_error_region(self):
+        env = self.env
+        env["SCOREP_EXPERIMENT_DIRECTORY"] += "/test_error_region"
+        trace_path = env["SCOREP_EXPERIMENT_DIRECTORY"] + "/traces.otf2"
+
+        out = call([self.python,
+                    "-m",
+                    "scorep",
+                    "--nocompiler",
+                    "--noinstrumenter",
+                    "test_error_region.py"],
+                   env=env)
+        std_out = out[1]
+        std_err = out[2]
+
+        self.assertEqual(
+            std_err,
+            "SCOREP_BINDING_PYTHON ERROR: There was a region exit without an enter!\n" +
+            "SCOREP_BINDING_PYTHON ERROR: For details look for \"error_region\" in the trace or profile.\n")
+        self.assertEqual(std_out, "")
+
+        out = call(["otf2-print", trace_path])
+        std_out = out[1]
+        std_err = out[2]
+
+        self.assertEqual(std_err, "")
+        self.assertRegex(std_out,
+                         'ENTER[ ]*[0-9 ]*[0-9 ]*Region: "error_region"')
+        self.assertRegex(std_out,
+                         'LEAVE[ ]*[0-9 ]*[0-9 ]*Region: "error_region"')
+        self.assertRegex(
+            std_out,
+            'PARAMETER_STRING[ ]*[0-9 ]*[0-9 ]*Parameter: "leave-region" <[0-9]*>,' +
+            ' Value: "user:test_region"')
+        self.assertRegex(
+            std_out,
+            'PARAMETER_STRING[ ]*[0-9 ]*[0-9 ]*Parameter: "leave-region" <[0-9]*>,' +
+            ' Value: "user:test_region_2"')
 
     @unittest.skipIf(len(pkgutil.extend_path([], "mpi4py")) == 0 or
                      len(pkgutil.extend_path([], "numpy")) == 0,
@@ -327,7 +365,7 @@ class TestScorepBindingsPython(unittest.TestCase):
             "Score-P directory exists for dummy test")
 
     def tearDown(self):
-        #pass
+        # pass
         shutil.rmtree(
             self.env["SCOREP_EXPERIMENT_DIRECTORY"],
             ignore_errors=True)

--- a/test/test_error_region.py
+++ b/test/test_error_region.py
@@ -1,0 +1,9 @@
+import scorep.user
+
+
+def foo():
+    scorep.user.region_end("test_region")
+    scorep.user.region_end("test_region_2")
+
+
+foo()


### PR DESCRIPTION
Instead of crashing or silently ignoring exit regions with no enter, annotate these regions as error regions.