### PR TITLE
Adapt to numpy NEP-18

### DIFF
--- a/scorep/instrumenters/scorep_profile.py
+++ b/scorep/instrumenters/scorep_profile.py
@@ -2,7 +2,7 @@ __all__ = ['ScorepProfile']
 import sys
 import inspect
 import os.path
-import logging
+
 try:
     import threading
 except ImportError:
@@ -81,8 +81,11 @@ class ScorepProfile:
             code = frame.f_code
             modulename = frame.f_globals.get('__name__', None)
             if modulename is None:
-                logging.error("unkonw module name, infos:\n{}, {}, {}".format(code.co_names, code.co_filename, code.co_firstlineno))                
-                modulename = "None"
+                # this is a NUMPY special situation, see NEP-18, and Score-P Issue issues #63
+                if code.co_filename == "<__array_function__ internals>":
+                    modulename = "numpy.__array_function__"
+                else:
+                    modulename = "unkown"
             if not code.co_name == "_unsetprofile" and not modulename[:6] == "scorep":
                 file_name = code.co_filename
                 if file_name is not None:
@@ -97,7 +100,11 @@ class ScorepProfile:
             code = frame.f_code
             modulename = frame.f_globals.get('__name__', None)
             if modulename is None:
-                modulename = "None"
+                # this is a NUMPY special situation, see NEP-18, and Score-P Issue issues #63
+                if code.co_filename == "<__array_function__ internals>":
+                    modulename = "numpy.__array_function__"
+                else:
+                    modulename = "unkown"
             if not code.co_name == "_unsetprofile" and not modulename[:6] == "scorep":
                 self.scorep_bindings.region_end(modulename, code.co_name)
         else:

--- a/scorep/instrumenters/scorep_profile.py
+++ b/scorep/instrumenters/scorep_profile.py
@@ -2,7 +2,7 @@ __all__ = ['ScorepProfile']
 import sys
 import inspect
 import os.path
-
+import logging
 try:
     import threading
 except ImportError:
@@ -81,14 +81,15 @@ class ScorepProfile:
             code = frame.f_code
             modulename = frame.f_globals.get('__name__', None)
             if modulename is None:
+                logging.error("unkonw module name, infos:\n{}, {}, {}".format(code.co_names, code.co_filename, code.co_firstlineno))                
                 modulename = "None"
             if not code.co_name == "_unsetprofile" and not modulename[:6] == "scorep":
-                file_name = frame.f_globals.get('__file__', None)
+                file_name = code.co_filename
                 if file_name is not None:
                     full_file_name = os.path.abspath(file_name)
                 else:
                     full_file_name = "None"
-                line_number = frame.f_lineno
+                line_number = code.co_firstlineno
                 self.scorep_bindings.region_begin(
                     modulename, code.co_name, full_file_name, line_number)
             return

--- a/scorep/instrumenters/scorep_trace.py
+++ b/scorep/instrumenters/scorep_trace.py
@@ -80,14 +80,18 @@ class ScorepTrace:
             code = frame.f_code
             modulename = frame.f_globals.get('__name__', None)
             if modulename is None:
-                modulename = "None"
+                # this is a NUMPY special situation, see NEP-18, and Score-P Issue issues #63
+                if code.co_filename == "<__array_function__ internals>":
+                    modulename = "numpy.__array_function__"
+                else:
+                    modulename = "unkown"
             if not code.co_name == "_unsettrace" and not modulename[:6] == "scorep":
-                file_name = frame.f_globals.get('__file__', None)
+                file_name = code.co_filename
                 if file_name is not None:
                     full_file_name = os.path.abspath(file_name)
                 else:
                     full_file_name = "None"
-                line_number = frame.f_lineno
+                line_number = code.co_firstlineno
                 self.scorep_bindings.region_begin(
                     modulename, code.co_name, full_file_name, line_number)
                 return self.localtrace
@@ -98,7 +102,11 @@ class ScorepTrace:
             code = frame.f_code
             modulename = frame.f_globals.get('__name__', None)
             if modulename is None:
-                modulename = "None"
+                # this is a NUMPY special situation, see NEP-18, and Score-P Issue issues #63
+                if code.co_filename == "<__array_function__ internals>":
+                    modulename = "numpy.__array_function__"
+                else:
+                    modulename = "unkown"
             self.scorep_bindings.region_end(modulename, code.co_name)
         return self.localtrace
 

--- a/test/test.py
+++ b/test/test.py
@@ -326,7 +326,7 @@ class TestScorepBindingsPython(unittest.TestCase):
                 env["SCOREP_EXPERIMENT_DIRECTORY"]),
             "Score-P directory exists for dummy test")
 
-    @unittest.skipIf(sys.version_info.major < 3)
+    @unittest.skipIf(sys.version_info.major < 3, "not tested for python 2")
     def test_numpy_dot(self):
         env = self.env
         env["SCOREP_EXPERIMENT_DIRECTORY"] += "/test_numpy_dot"

--- a/test/test.py
+++ b/test/test.py
@@ -335,13 +335,15 @@ class TestScorepBindingsPython(unittest.TestCase):
                     "-m",
                     "scorep",
                     "--nocompiler",
+                    "--noinstrumenter",
                     "test_numpy_dot.py"],
                    env=env)
         std_out = out[1]
         std_err = out[2]
 
+        self.assertEqual(std_out, "[[ 7 10]\n [15 22]]\n")
         self.assertEqual(std_err, self.expected_std_err)
-        self.assertEqual(std_out, "[]")
+        
 
         out = call(["otf2-print", trace_path])
         std_out = out[1]
@@ -349,16 +351,16 @@ class TestScorepBindingsPython(unittest.TestCase):
 
         self.assertEqual(std_err, "")
         self.assertRegex(std_out,
-                         'ENTER[ ]*[0-9 ]*[0-9 ]*Region: "numpy:dot"')
+                         'ENTER[ ]*[0-9 ]*[0-9 ]*Region: "numpy.__array_function__:dot"')
         self.assertRegex(std_out,
-                         'LEAVE[ ]*[0-9 ]*[0-9 ]*Region: "numpy:dot"')
+                         'LEAVE[ ]*[0-9 ]*[0-9 ]*Region: "numpy.__array_function__:dot"')
 
 
     def tearDown(self):
-        pass
-        #shutil.rmtree(
-        #    self.env["SCOREP_EXPERIMENT_DIRECTORY"],
-        #    ignore_errors=True)
+        #pass
+        shutil.rmtree(
+            self.env["SCOREP_EXPERIMENT_DIRECTORY"],
+            ignore_errors=True)
 
 
 if __name__ == '__main__':

--- a/test/test.py
+++ b/test/test.py
@@ -326,6 +326,7 @@ class TestScorepBindingsPython(unittest.TestCase):
                 env["SCOREP_EXPERIMENT_DIRECTORY"]),
             "Score-P directory exists for dummy test")
 
+    @unittest.skipIf(sys.version_info.major < 3)
     def test_numpy_dot(self):
         env = self.env
         env["SCOREP_EXPERIMENT_DIRECTORY"] += "/test_numpy_dot"

--- a/test/test.py
+++ b/test/test.py
@@ -326,11 +326,39 @@ class TestScorepBindingsPython(unittest.TestCase):
                 env["SCOREP_EXPERIMENT_DIRECTORY"]),
             "Score-P directory exists for dummy test")
 
+    def test_numpy_dot(self):
+        env = self.env
+        env["SCOREP_EXPERIMENT_DIRECTORY"] += "/test_numpy_dot"
+        trace_path = env["SCOREP_EXPERIMENT_DIRECTORY"] + "/traces.otf2"
+
+        out = call([self.python,
+                    "-m",
+                    "scorep",
+                    "--nocompiler",
+                    "test_numpy_dot.py"],
+                   env=env)
+        std_out = out[1]
+        std_err = out[2]
+
+        self.assertEqual(std_err, self.expected_std_err)
+        self.assertEqual(std_out, "[]")
+
+        out = call(["otf2-print", trace_path])
+        std_out = out[1]
+        std_err = out[2]
+
+        self.assertEqual(std_err, "")
+        self.assertRegex(std_out,
+                         'ENTER[ ]*[0-9 ]*[0-9 ]*Region: "numpy:dot"')
+        self.assertRegex(std_out,
+                         'LEAVE[ ]*[0-9 ]*[0-9 ]*Region: "numpy:dot"')
+
+
     def tearDown(self):
-        #pass
-        shutil.rmtree(
-            self.env["SCOREP_EXPERIMENT_DIRECTORY"],
-            ignore_errors=True)
+        pass
+        #shutil.rmtree(
+        #    self.env["SCOREP_EXPERIMENT_DIRECTORY"],
+        #    ignore_errors=True)
 
 
 if __name__ == '__main__':

--- a/test/test_numpy_dot.py
+++ b/test/test_numpy_dot.py
@@ -1,8 +1,9 @@
 import numpy
+import scorep.instrumenter
 
-a = [[1,2],[3,4]]
-b = [[1,2],[3,4]]
-
-c = numpy.dot(a,b)
-
-print(c)
+with scorep.instrumenter.enable():
+    a = [[1, 2],[3, 4]] 
+    b = [[1, 2],[3, 4]]
+    
+    c = numpy.dot(a,b)
+    print(c)

--- a/test/test_numpy_dot.py
+++ b/test/test_numpy_dot.py
@@ -1,0 +1,8 @@
+import numpy
+
+a = [[1,2],[3,4]]
+b = [[1,2],[3,4]]
+
+c = numpy.dot(a,b)
+
+print(c)


### PR DESCRIPTION
Fix Issue #63 .

Together with the introduction of [NEP-18](https://numpy.org/neps/nep-0018-array-function-protocol.html) some numpy functions appear with `None:dot`. The `None` is misleading. The solution discussed in #63 is to make the reference to numpy and the related function `__array_function__` explicit. 

As we are already started using `co_filename`, we changed to `co` functions as well.