### PR TITLE
Add CI via Github actions

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -1,0 +1,27 @@
+name: Static analysis
+on: [push, pull_request]
+
+jobs:
+  Cpp:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Formatting
+      uses: Flamefire/clang-format-lint-action@master
+      with:
+        source: src
+        clangFormatVersion: 9
+
+  Python:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install Python packages
+      run: |
+        pip install --upgrade pip
+        pip install --upgrade flake8
+    - name: Run flake8
+      run: flake8 benchmark scorep test

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,0 +1,56 @@
+name: Unit tests
+on: [push, pull_request]
+
+env:
+  SCOREP_TIMER: clock_gettime # tsc causes warnings
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        python: [2.7, 3.5, 3.6, 3.7, 3.8]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v1
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip
+    - id: cache
+      uses: actions/cache@v1
+      with:
+        path: ~/scorep
+        key: scorep
+
+    - name: Install system dependencies
+      run: sudo apt install gcc-7-plugin-dev libopenmpi-dev openmpi-bin
+    - name: Install dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        mkdir /tmp/buildScorep && cd /tmp/buildScorep
+        wget https://www.vi-hps.org/cms/upload/packages/scorep/scorep-6.0.tar.gz
+        tar xf scorep-6.0.tar.gz
+        cd scorep-6.0
+        mkdir build && cd build
+        ../configure --enable-shared --prefix=$HOME/scorep
+        make -j3 && make install
+
+    - name: Setup environment
+      run: echo "::add-path::$HOME/scorep/bin"
+    - name: set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{matrix.python}}
+        architecture: x64
+    - name: Install Python packages
+      run: |
+        pip install --upgrade pip
+        pip install numpy mpi4py
+
+    - name: Build python bindings
+      run: pip install .
+    - name: Run tests
+      working-directory: test
+      run: ./test.py

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![Build Status](https://travis-ci.com/score-p/scorep_binding_python.svg?branch=master)](https://travis-ci.com/score-p/scorep_binding_python)
+[![Unit tests](https://github.com/score-p/scorep_binding_python/workflows/Unit%20tests/badge.svg?branch=master)](https://github.com/score-p/scorep_binding_python/actions?query=workflow%3A"Unit+tests")
+[![Static analysis](https://github.com/score-p/scorep_binding_python/workflows/Static%20analysis/badge.svg?branch=master)](https://github.com/score-p/scorep_binding_python/actions?query=workflow%3A"Static+analysis")
 
 # scorep
 scorep is a module that allows tracing of python scripts using [Score-P](http://www.vi-hps.org/projects/score-p/).


### PR DESCRIPTION
This adds CI tests via Github actions where it installs scorep and this module and runs `test/test.py`

It also checks formatting (as per clang-format-9) and for Python issues (via flake8)

See commits for details