### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.ccls-cache
+BUILD
+build
+/scorep.egg-info


### PR DESCRIPTION
Contains common files created e.g. by IDEs (build folder) and by pip (/scorep.egg-info)

This avoids accidentally committing build artifacts and leads to less polluted `git status` output

Factored out from #68

Regarding comments:

> This requires me to add the files I need to ignore to the repo (e.g. from eclipse)

You are not required to do this. If you are fine with `git status` showing your IDE files you don't need to do anything

> which ends up in a total mess of files if any developer does this.

What mess? This is a text file and there are only some common files/folders which are recreated very frequently. The .gitignore file is meant to reduce the mess `git status` shows which will then show a clean working tree when it is clean (in terms of git)

> adding e.g. /scorep.egg-info will prevent git clean -df from working "correctly", and removing all build files.

For that use case use `git clean -dfx` which does also remove ignored files

--> In summary it helps to focus on the important files especially when adding new ones