### PR TITLE
Add scorep_instrumenter_base to heavily reduce code duplication

### DIFF
--- a/scorep/instrumenters/base_instrumenter.py
+++ b/scorep/instrumenters/base_instrumenter.py
@@ -1,29 +1,7 @@
 __all__ = ['BaseInstrumenter']
 
 import abc
-import os
 import sys
-
-
-def get_module_name(frame):
-    modulename = frame.f_globals.get('__name__', None)
-    if modulename is None:
-        # this is a NUMPY special situation, see NEP-18, and Score-P Issue
-        # issues #63
-        if frame.f_code.co_filename == "<__array_function__ internals>":
-            modulename = "numpy.__array_function__"
-        else:
-            modulename = "unkown"
-    return modulename
-
-
-def get_file_name(frame):
-    file_name = frame.f_code.co_filename
-    if file_name is not None:
-        full_file_name = os.path.abspath(file_name)
-    else:
-        full_file_name = "None"
-    return full_file_name
 
 
 if sys.version_info >= (3, 4):

--- a/scorep/instrumenters/scorep_instrumenter.py
+++ b/scorep/instrumenters/scorep_instrumenter.py
@@ -4,7 +4,7 @@ import os
 from scorep.instrumenters import base_instrumenter
 
 
-class ScorepInstrumenterBase(base_instrumenter.BaseInstrumenter):
+class ScorepInstrumenter(base_instrumenter.BaseInstrumenter):
     """Base class for all instrumenters using Score-P"""
 
     def __init__(self, scorep_bindings, enable_instrumenter=True):
@@ -40,14 +40,7 @@ class ScorepInstrumenterBase(base_instrumenter.BaseInstrumenter):
         """Return whether this instrumenter is currently collecting events"""
         return self._tracer_registered
 
-    def run(self, cmd):
-        """
-        Run the compiled command.
-        Registers this instrumenter for the duration of the command and unregisters it afterwards
-        """
-        self.runctx(cmd)
-
-    def runctx(self, cmd, globals=None, locals=None):
+    def run(self, cmd, globals=None, locals=None):
         """
         Run the compiled command.
         Registers this instrumenter for the duration of the command and unregisters it afterwards
@@ -62,20 +55,6 @@ class ScorepInstrumenterBase(base_instrumenter.BaseInstrumenter):
             exec(cmd, globals, locals)
         finally:
             self.unregister()
-
-    def runfunc(self, func, *args, **kw):
-        """
-        Run the python function.
-        Registers this instrumenter for the duration of the function and unregisters it afterwards
-        """
-        result = None
-        if self._enabled:
-            self.register()
-        try:
-            result = func(*args, **kw)
-        finally:
-            self.unregister()
-        return result
 
     def region_begin(self, module_name, function_name, file_name, line_number):
         """Record a region begin event"""

--- a/scorep/instrumenters/scorep_instrumenter.py
+++ b/scorep/instrumenters/scorep_instrumenter.py
@@ -41,9 +41,9 @@ class ScorepInstrumenter(base_instrumenter.BaseInstrumenter):
         return self._tracer_registered
 
     def run(self, cmd, globals=None, locals=None):
-        """
-        Run the compiled command.
-        Registers this instrumenter for the duration of the command and unregisters it afterwards
+        """Run the compiled command under this instrumenter.
+
+        When the instrumenter is enabled it is registered prior to the invocation and unregistered afterwards
         """
         if globals is None:
             globals = {}

--- a/scorep/instrumenters/scorep_instrumenter_base.py
+++ b/scorep/instrumenters/scorep_instrumenter_base.py
@@ -1,0 +1,157 @@
+import abc
+import inspect
+import os
+from scorep.instrumenters import base_instrumenter
+
+
+class ScorepInstrumenterBase(base_instrumenter.BaseInstrumenter):
+    """Base class for all instrumenters using Score-P"""
+
+    def __init__(self, scorep_bindings, enable_instrumenter=True):
+        """
+        @param enable_instrumenter true if the tracing shall be initialised.
+            Please note, that it is still possible to enable the tracing later using register()
+        """
+        self._scorep_bindings = scorep_bindings
+        self._tracer_registered = False
+        self._enabled = enable_instrumenter
+
+    @abc.abstractmethod
+    def _enable_instrumenter(self):
+        """Actually enable this instrumenter to collect events"""
+
+    @abc.abstractmethod
+    def _disable_instrumenter(self):
+        """Stop this instrumenter from collecting events"""
+
+    def register(self):
+        """Register this instrumenter (collect events)"""
+        if not self._tracer_registered:
+            self._enable_instrumenter()
+            self._tracer_registered = True
+
+    def unregister(self):
+        """Unregister this instrumenter (stop collecting events)"""
+        if self._tracer_registered:
+            self._disable_instrumenter()
+            self._tracer_registered = False
+
+    def get_registered(self):
+        """Return whether this instrumenter is currently collecting events"""
+        return self._tracer_registered
+
+    def run(self, cmd):
+        """
+        Run the compiled command.
+        Registers this instrumenter for the duration of the command and unregisters it afterwards
+        """
+        self.runctx(cmd)
+
+    def runctx(self, cmd, globals=None, locals=None):
+        """
+        Run the compiled command.
+        Registers this instrumenter for the duration of the command and unregisters it afterwards
+        """
+        if globals is None:
+            globals = {}
+        if locals is None:
+            locals = {}
+        if self._enabled:
+            self.register()
+        try:
+            exec(cmd, globals, locals)
+        finally:
+            self.unregister()
+
+    def runfunc(self, func, *args, **kw):
+        """
+        Run the python function.
+        Registers this instrumenter for the duration of the function and unregisters it afterwards
+        """
+        result = None
+        if self._enabled:
+            self.register()
+        try:
+            result = func(*args, **kw)
+        finally:
+            self.unregister()
+        return result
+
+    def region_begin(self, module_name, function_name, file_name, line_number):
+        """Record a region begin event"""
+        self._scorep_bindings.region_begin(
+            module_name, function_name, file_name, line_number)
+
+    def region_end(self, module_name, function_name):
+        """Record a region end event"""
+        self._scorep_bindings.region_end(module_name, function_name)
+
+    def rewind_begin(self, name, file_name=None, line_number=None):
+        """
+        Begin of an Rewind region. If file_name or line_number is None, both will
+        be determined automatically
+        @param name name of the user region
+        @param file_name file name of the user region
+        @param line_number line number of the user region
+        """
+        if file_name is None or line_number is None:
+            frame = inspect.currentframe().f_back
+            file_name = frame.f_globals.get('__file__', None)
+            line_number = frame.f_lineno
+        if file_name is not None:
+            full_file_name = os.path.abspath(file_name)
+        else:
+            full_file_name = "None"
+
+        self._scorep_bindings.rewind_begin(name, full_file_name, line_number)
+
+    def rewind_end(self, name, value):
+        """
+        End of an Rewind region.
+        @param name name of the user region
+        @param value True or False, whenether the region shall be rewinded or not.
+        """
+        self._scorep_bindings.rewind_end(name, value)
+
+    def oa_region_begin(self, name, file_name=None, line_number=None):
+        """
+        Begin of an Online Access region. If file_name or line_number is None, both will
+        be determined automatically
+        @param name name of the user region
+        @param file_name file name of the user region
+        @param line_number line number of the user region
+        """
+        if file_name is None or line_number is None:
+            frame = inspect.currentframe().f_back
+            file_name = frame.f_globals.get('__file__', None)
+            line_number = frame.f_lineno
+        if file_name is not None:
+            full_file_name = os.path.abspath(file_name)
+        else:
+            full_file_name = "None"
+
+        self._scorep_bindings.oa_region_begin(name, full_file_name, line_number)
+
+    def oa_region_end(self, name):
+        """End an Online Access region."""
+        self._scorep_bindings.oa_region_end(name)
+
+    def user_enable_recording(self):
+        """Enable writing of trace events in ScoreP"""
+        self._scorep_bindings.enable_recording()
+
+    def user_disable_recording(self):
+        """Disable writing of trace events in ScoreP"""
+        self._scorep_bindings.disable_recording()
+
+    def user_parameter_int(self, name, val):
+        """Record a parameter of type integer"""
+        self._scorep_bindings.parameter_int(name, val)
+
+    def user_parameter_uint(self, name, val):
+        """Record a parameter of type unsigned integer"""
+        self._scorep_bindings.parameter_string(name, val)
+
+    def user_parameter_string(self, name, string):
+        """Record a parameter of type string"""
+        self._scorep_bindings.parameter_string(name, string)

--- a/scorep/instrumenters/scorep_profile.py
+++ b/scorep/instrumenters/scorep_profile.py
@@ -2,7 +2,7 @@ __all__ = ['ScorepProfile']
 
 import sys
 from scorep.instrumenters.base_instrumenter import get_module_name, get_file_name
-from scorep.instrumenters.scorep_instrumenter_base import ScorepInstrumenterBase
+from scorep.instrumenters.scorep_instrumenter import ScorepInstrumenter
 
 try:
     import threading
@@ -22,7 +22,7 @@ else:
         threading.setprofile(None)
 
 
-class ScorepProfile(ScorepInstrumenterBase):
+class ScorepProfile(ScorepInstrumenter):
     def _enable_instrumenter(self):
         _setprofile(self._globaltrace)
 

--- a/scorep/instrumenters/scorep_profile.py
+++ b/scorep/instrumenters/scorep_profile.py
@@ -1,7 +1,7 @@
 __all__ = ['ScorepProfile']
 
 import sys
-from scorep.instrumenters.base_instrumenter import get_module_name, get_file_name
+from scorep.instrumenters.utils import get_module_name, get_file_name
 from scorep.instrumenters.scorep_instrumenter import ScorepInstrumenter
 
 try:

--- a/scorep/instrumenters/scorep_profile.py
+++ b/scorep/instrumenters/scorep_profile.py
@@ -1,9 +1,8 @@
 __all__ = ['ScorepProfile']
 
 import sys
-import inspect
-import os.path
-import scorep.instrumenters.base_instrumenter as base_instrumenter
+from scorep.instrumenters.base_instrumenter import get_module_name, get_file_name
+from scorep.instrumenters.scorep_instrumenter_base import ScorepInstrumenterBase
 
 try:
     import threading
@@ -23,44 +22,14 @@ else:
         threading.setprofile(None)
 
 
-class ScorepProfile(base_instrumenter.BaseInstrumenter):
-    def __init__(self, scorep_bindings, enable_instrumenter=True):
-        """
-        @param enable_instrumenter true if the tracing shall be initialised.
-            Please note, that it is still possible to enable the tracing later using register()
-        """
-        global global_instrumenter
-        global_instrumenter = self
-        self.tracer_registered = False
+class ScorepProfile(ScorepInstrumenterBase):
+    def _enable_instrumenter(self):
+        _setprofile(self._globaltrace)
 
-        self.scorep_bindings = scorep_bindings
-        self.globaltrace = self.globaltrace_lt
-        self.enable_instrumenter = enable_instrumenter
-
-    def register(self):
-        self.tracer_registered = True
-        _setprofile(self.globaltrace)
-
-    def unregister(self):
+    def _disable_instrumenter(self):
         _unsetprofile()
-        self.tracer_registered = False
 
-    def get_registered(self):
-        return self.tracer_registered
-
-    def run(self, cmd, globals=None, locals=None):
-        if globals is None:
-            globals = {}
-        if locals is None:
-            locals = {}
-        if self.enable_instrumenter:
-            self.register()
-        try:
-            exec(cmd, globals, locals)
-        finally:
-            self.unregister()
-
-    def globaltrace_lt(self, frame, why, arg):
+    def _globaltrace(self, frame, why, arg):
         """Handler for call events.
 
         If the code block being entered is to be ignored, returns `None',
@@ -68,88 +37,13 @@ class ScorepProfile(base_instrumenter.BaseInstrumenter):
         """
         if why == 'call':
             code = frame.f_code
-            modulename = base_instrumenter.get_module_name(frame)
+            modulename = get_module_name(frame)
             if not code.co_name == "_unsetprofile" and not modulename[:6] == "scorep":
-                full_file_name = base_instrumenter.get_file_name(frame)
+                full_file_name = get_file_name(frame)
                 line_number = code.co_firstlineno
-                self.scorep_bindings.region_begin(
-                    modulename, code.co_name, full_file_name, line_number)
-            return
+                self.region_begin(modulename, code.co_name, full_file_name, line_number)
         elif why == 'return':
             code = frame.f_code
-            modulename = base_instrumenter.get_module_name(frame)
+            modulename = get_module_name(frame)
             if not code.co_name == "_unsetprofile" and not modulename[:6] == "scorep":
-                self.scorep_bindings.region_end(modulename, code.co_name)
-        else:
-            return
-
-    def region_begin(self, module_name, function_name, file_name, line_number):
-        self.scorep_bindings.region_begin(
-            module_name, function_name, file_name, line_number)
-
-    def region_end(self, module_name, function_name):
-        self.scorep_bindings.region_end(module_name, function_name)
-
-    def rewind_begin(self, name, file_name=None, line_number=None):
-        """
-        Begin of an Rewind region. If file_name or line_number is None, both will
-        bet determined automatically
-        @param name name of the user region
-        @param file_name file name of the user region
-        @param line_number line number of the user region
-        """
-        if file_name is None or line_number is None:
-            frame = inspect.currentframe().f_back
-            file_name = frame.f_globals.get('__file__', None)
-            line_number = frame.f_lineno
-        if file_name is not None:
-            full_file_name = os.path.abspath(file_name)
-        else:
-            full_file_name = "None"
-
-        self.scorep_bindings.rewind_begin(name, full_file_name, line_number)
-
-    def rewind_end(self, name, value):
-        """
-        End of an Rewind region.
-        @param name name of the user region
-        @param value True or False, whenether the region shall be rewinded or not.
-        """
-        self.scorep_bindings.rewind_end(name, value)
-
-    def oa_region_begin(self, name, file_name=None, line_number=None):
-        """
-        Begin of an Online Access region. If file_name or line_number is None, both will
-        bet determined automatically
-        @param name name of the user region
-        @param file_name file name of the user region
-        @param line_number line number of the user region
-        """
-        if file_name is None or line_number is None:
-            frame = inspect.currentframe().f_back
-            file_name = frame.f_globals.get('__file__', None)
-            line_number = frame.f_lineno
-        if file_name is not None:
-            full_file_name = os.path.abspath(file_name)
-        else:
-            full_file_name = "None"
-
-        self.scorep_bindings.oa_region_begin(name, full_file_name, line_number)
-
-    def oa_region_end(self, name):
-        self.scorep_bindings.oa_region_end(name)
-
-    def user_enable_recording(self):
-        self.scorep_bindings.enable_recording()
-
-    def user_disable_recording(self):
-        self.scorep_bindings.disable_recording()
-
-    def user_parameter_int(self, name, val):
-        self.scorep_bindings.parameter_int(name, val)
-
-    def user_parameter_uint(self, name, val):
-        self.scorep_bindings.parameter_string(name, val)
-
-    def user_parameter_string(self, name, string):
-        self.scorep_bindings.parameter_string(name, string)
+                self.region_end(modulename, code.co_name)

--- a/scorep/instrumenters/scorep_profile.py
+++ b/scorep/instrumenters/scorep_profile.py
@@ -41,9 +41,9 @@ class ScorepProfile(ScorepInstrumenter):
             if not code.co_name == "_unsetprofile" and not modulename[:6] == "scorep":
                 full_file_name = get_file_name(frame)
                 line_number = code.co_firstlineno
-                self.region_begin(modulename, code.co_name, full_file_name, line_number)
+                self._scorep_bindings.region_begin(modulename, code.co_name, full_file_name, line_number)
         elif why == 'return':
             code = frame.f_code
             modulename = get_module_name(frame)
             if not code.co_name == "_unsetprofile" and not modulename[:6] == "scorep":
-                self.region_end(modulename, code.co_name)
+                self._scorep_bindings.region_end(modulename, code.co_name)

--- a/scorep/instrumenters/scorep_trace.py
+++ b/scorep/instrumenters/scorep_trace.py
@@ -1,9 +1,8 @@
 __all__ = ['ScorepTrace']
 
 import sys
-import inspect
-import os.path
-import scorep.instrumenters.base_instrumenter as base_instrumenter
+from scorep.instrumenters.base_instrumenter import get_module_name, get_file_name
+from scorep.instrumenters.scorep_instrumenter_base import ScorepInstrumenterBase
 
 try:
     import threading
@@ -23,133 +22,30 @@ else:
         threading.settrace(None)
 
 
-class ScorepTrace(base_instrumenter.BaseInstrumenter):
-    def __init__(self, scorep_bindings, enable_instrumenter=True):
-        """
-        @param enable_instrumenter true if the tracing shall be initialised.
-            Please note, that it is still possible to enable the tracing later using register()
-        """
-        global global_instrumenter
-        global_instrumenter = self
-        self.tracer_registered = False
+class ScorepTrace(ScorepInstrumenterBase):
+    def _enable_instrumenter(self):
+        _settrace(self._globaltrace)
 
-        self.scorep_bindings = scorep_bindings
-        self.globaltrace = self.globaltrace_lt
-        self.localtrace = self.localtrace_trace
-        self.enable_instrumenter = enable_instrumenter
-
-    def register(self):
-        self.tracer_registered = True
-        _settrace(self.globaltrace)
-
-    def unregister(self):
+    def _disable_instrumenter(self):
         _unsettrace()
-        self.tracer_registered = False
 
-    def get_registered(self):
-        return self.tracer_registered
-
-    def run(self, cmd, globals=None, locals=None):
-        if globals is None:
-            globals = {}
-        if locals is None:
-            locals = {}
-        if self.enable_instrumenter:
-            self.register()
-        try:
-            exec(cmd, globals, locals)
-        finally:
-            self.unregister()
-
-    def globaltrace_lt(self, frame, why, arg):
+    def _globaltrace(self, frame, why, arg):
         """Handler for call events.
         @return self.localtrace or None
         """
         if why == 'call':
             code = frame.f_code
-            modulename = base_instrumenter.get_module_name(frame)
+            modulename = get_module_name(frame)
             if not code.co_name == "_unsettrace" and not modulename[:6] == "scorep":
-                full_file_name = base_instrumenter.get_file_name(frame)
+                full_file_name = get_file_name(frame)
                 line_number = code.co_firstlineno
-                self.scorep_bindings.region_begin(
-                    modulename, code.co_name, full_file_name, line_number)
-                return self.localtrace
+                self.region_begin(modulename, code.co_name, full_file_name, line_number)
+                return self._localtrace
         return None
 
-    def localtrace_trace(self, frame, why, arg):
+    def _localtrace(self, frame, why, arg):
         if why == 'return':
             code = frame.f_code
-            modulename = base_instrumenter.get_module_name(frame)
-            self.scorep_bindings.region_end(modulename, code.co_name)
-        return self.localtrace
-
-    def region_begin(self, module_name, function_name, file_name, line_number):
-        self.scorep_bindings.region_begin(
-            module_name, function_name, file_name, line_number)
-
-    def region_end(self, module_name, function_name):
-        self.scorep_bindings.region_end(module_name, function_name)
-
-    def rewind_begin(self, name, file_name=None, line_number=None):
-        """
-        Begin of an Rewind region. If file_name or line_number is None, both will
-        bet determined automatically
-        @param name name of the user region
-        @param file_name file name of the user region
-        @param line_number line number of the user region
-        """
-        if file_name is None or line_number is None:
-            frame = inspect.currentframe().f_back
-            file_name = frame.f_globals.get('__file__', None)
-            line_number = frame.f_lineno
-        if file_name is not None:
-            full_file_name = os.path.abspath(file_name)
-        else:
-            full_file_name = "None"
-
-        self.scorep_bindings.rewind_begin(name, full_file_name, line_number)
-
-    def rewind_end(self, name, value):
-        """
-        End of an Rewind region.
-        @param name name of the user region
-        @param value True or False, whenether the region shall be rewinded or not.
-        """
-        self.scorep_bindings.rewind_end(name, value)
-
-    def oa_region_begin(self, name, file_name=None, line_number=None):
-        """
-        Begin of an Online Access region. If file_name or line_number is None, both will
-        bet determined automatically
-        @param name name of the user region
-        @param file_name file name of the user region
-        @param line_number line number of the user region
-        """
-        if file_name is None or line_number is None:
-            frame = inspect.currentframe().f_back
-            file_name = frame.f_globals.get('__file__', None)
-            line_number = frame.f_lineno
-        if file_name is not None:
-            full_file_name = os.path.abspath(file_name)
-        else:
-            full_file_name = "None"
-
-        self.scorep_bindings.oa_region_begin(name, full_file_name, line_number)
-
-    def oa_region_end(self, name):
-        self.scorep_bindings.oa_region_end(name)
-
-    def user_enable_recording(self):
-        self.scorep_bindings.enable_recording()
-
-    def user_disable_recording(self):
-        self.scorep_bindings.disable_recording()
-
-    def user_parameter_int(self, name, val):
-        self.scorep_bindings.parameter_int(name, val)
-
-    def user_parameter_uint(self, name, val):
-        self.scorep_bindings.parameter_string(name, val)
-
-    def user_parameter_string(self, name, string):
-        self.scorep_bindings.parameter_string(name, string)
+            modulename = get_module_name(frame)
+            self.region_end(modulename, code.co_name)
+        return self._localtrace

--- a/scorep/instrumenters/scorep_trace.py
+++ b/scorep/instrumenters/scorep_trace.py
@@ -39,7 +39,7 @@ class ScorepTrace(ScorepInstrumenter):
             if not code.co_name == "_unsettrace" and not modulename[:6] == "scorep":
                 full_file_name = get_file_name(frame)
                 line_number = code.co_firstlineno
-                self.region_begin(modulename, code.co_name, full_file_name, line_number)
+                self._scorep_bindings.region_begin(modulename, code.co_name, full_file_name, line_number)
                 return self._localtrace
         return None
 
@@ -47,5 +47,5 @@ class ScorepTrace(ScorepInstrumenter):
         if why == 'return':
             code = frame.f_code
             modulename = get_module_name(frame)
-            self.region_end(modulename, code.co_name)
+            self._scorep_bindings.region_end(modulename, code.co_name)
         return self._localtrace

--- a/scorep/instrumenters/scorep_trace.py
+++ b/scorep/instrumenters/scorep_trace.py
@@ -2,7 +2,7 @@ __all__ = ['ScorepTrace']
 
 import sys
 from scorep.instrumenters.base_instrumenter import get_module_name, get_file_name
-from scorep.instrumenters.scorep_instrumenter_base import ScorepInstrumenterBase
+from scorep.instrumenters.scorep_instrumenter import ScorepInstrumenter
 
 try:
     import threading
@@ -22,7 +22,7 @@ else:
         threading.settrace(None)
 
 
-class ScorepTrace(ScorepInstrumenterBase):
+class ScorepTrace(ScorepInstrumenter):
     def _enable_instrumenter(self):
         _settrace(self._globaltrace)
 

--- a/scorep/instrumenters/scorep_trace.py
+++ b/scorep/instrumenters/scorep_trace.py
@@ -1,7 +1,7 @@
 __all__ = ['ScorepTrace']
 
 import sys
-from scorep.instrumenters.base_instrumenter import get_module_name, get_file_name
+from scorep.instrumenters.utils import get_module_name, get_file_name
 from scorep.instrumenters.scorep_instrumenter import ScorepInstrumenter
 
 try:

--- a/scorep/instrumenters/utils.py
+++ b/scorep/instrumenters/utils.py
@@ -1,0 +1,24 @@
+import os
+
+
+def get_module_name(frame):
+    """Get the name of the module the given frame resides in"""
+    modulename = frame.f_globals.get('__name__', None)
+    if modulename is None:
+        # this is a NUMPY special situation, see NEP-18, and Score-P Issue
+        # issues #63
+        if frame.f_code.co_filename == "<__array_function__ internals>":
+            modulename = "numpy.__array_function__"
+        else:
+            modulename = "unkown"
+    return modulename
+
+
+def get_file_name(frame):
+    """Get the full path to the file the given frame resides in"""
+    file_name = frame.f_code.co_filename
+    if file_name is not None:
+        full_file_name = os.path.abspath(file_name)
+    else:
+        full_file_name = "None"
+    return full_file_name


### PR DESCRIPTION
This introduces the base class `ScorepInstrumenterBase` to contain all common functionality and state of instrumenters, at least the ones actually doing something (i.e. not the DummyInstrumenter)

Note: Use the side-by-side diff to view this.

Notable design choices:
- As per Python convention/rules private members are prefixed by `_`, linters will warn when accessing those from outside and it makes the intention clear
- register/unregister check the current state and call an abstract method, again unifiying duplicated and possibly inconsistent code
- methods are documented (synthesized from implementation, correct me where I got it wrong)
- Creating an instrumenter does not set the `global_instrumenter` anymore. That logic was... fishy as it wasn't clear where that global was defined. Also it raises a question: Are users supposed to instantiate instrumenters themselves? If so it would be surprising that creating an instrumenter resets the registered instrumenter set by `scorep.instrumenter.get_instrumenter` and hence that should only be set by that function. Related: `get_instrumenter` might return another instrumenter as requested.

Things I would change:   
1. Why are those called "Instrumenters" when they have forwarding functions `*_begin`/`_end`? I would move all that functionality into the `scorep.user` module and have the instrumenters instrument only. Downside: The dummy instrumenter behavior would change, but using `disable_recording` is the better choice anyway
2. The `run` and `runctx` are a bit strange and only one of those `run*` functions is used. Maybe simplify and at least remove one of those 2? The other one should be tested.
3. Instrumenters should/could be context managers itself, similar to `instrumenters.enable`. `with instrumenter:` to instrument a region makes sense IMO
4. The ABC `BaseInstrumenter` could be replaced by the `ScorepInstrumenterBase` to further simplify the code, especially after addressing 1. As shown you can use abstract methods in a "regular" class and currently the `BaseInstrumenter` is very much lacking: No documentation at all what those method do, merely the signature. The only advantage I see is that it shows errors if e.g. DummyInstrumenter forgot to override a message
5. Split `get_instrumenter` in `create_instrumenter` and `get_instrumenter` where the latter throws when none has been set. Currently there will be an issue as the default created instrumenter does e.g. have no C-bindings set which will raise an obscure error somewhere later
6. Generally specify which parts are "private"/implementation details/not for users by using the underscore-convention on functions and modules