### PR TITLE
Fix python styling and flake8 issues

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,5 @@
 [pycodestyle]
 max_line_length = 120
 indent-size = 4
+[flake8]
+max_line_length = 120

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -10,15 +10,14 @@ bench = benchmark_helper.BenchmarkEnv(repetitions=51)
 tests = ["test_1.py", "test_2.py"]
 results = {}
 
-reps_x={}
-reps_x["test_1.py"]=["1000000", "2000000", "3000000", "4000000", "5000000"]
-reps_x["test_2.py"]=["100000", "200000", "300000", "400000", "500000"] 
-
+reps_x = {}
+reps_x["test_1.py"] = ["1000000", "2000000", "3000000", "4000000", "5000000"]
+reps_x["test_2.py"] = ["100000", "200000", "300000", "400000", "500000"]
 
 for test in tests:
     results[test] = {"profile": {}, "trace": {}, "dummy": {}, "None": {}}
     for instrumenter in results[test]:
-        if instrumenter is "None":
+        if instrumenter == "None":
             enable_scorep = False
             scorep_settings = []
         else:
@@ -29,11 +28,9 @@ for test in tests:
         print("{}: {}".format(test, scorep_settings))
         print("#########")
         for reps in reps_x[test]:
-            times = bench.call(
-                test,
-                [reps],
-                enable_scorep,
-                scorep_settings=scorep_settings)
+            times = bench.call(test, [reps],
+                               enable_scorep,
+                               scorep_settings=scorep_settings)
             results[test][instrumenter][reps] = times
             print("{:<8}: {}".format(reps, times))
 

--- a/benchmark/benchmark_helper.py
+++ b/benchmark/benchmark_helper.py
@@ -40,7 +40,7 @@ class BenchmarkEnv():
         runtimes = []
         for i in range(self.repetitions):
             begin = time.time()
-            print (arguments)
+            print(arguments)
             out = subprocess.run(
                 arguments,
                 env=self.env,

--- a/scorep/__init__.py
+++ b/scorep/__init__.py
@@ -1,3 +1,1 @@
-import scorep.user
-import scorep.instrumenter
 __all__ = ["user", "instrumenter"]

--- a/scorep/__main__.py
+++ b/scorep/__main__.py
@@ -66,7 +66,6 @@ def scorep_main(argv=None):
             os.environ["SCOREP_PYTHON_BINDINGS_INITALISED"] != "true"):
         scorep.subsystem.init_environment(scorep_config, keep_files)
         os.environ["SCOREP_PYTHON_BINDINGS_INITALISED"] = "true"
-
         """
         python -m starts the module as skript. i.e. sys.argv will loke like:
         ['/home/gocht/Dokumente/code/scorep_python/scorep.py', '--mpi', 'mpi_test.py']
@@ -91,8 +90,9 @@ def scorep_main(argv=None):
     progname = prog_argv[0]
     sys.path[0] = os.path.split(progname)[0]
 
-    tracer = scorep.instrumenter.get_instrumenter(
-        scorep_bindings, not no_instrumenter, instrumenter_type)
+    tracer = scorep.instrumenter.get_instrumenter(scorep_bindings,
+                                                  not no_instrumenter,
+                                                  instrumenter_type)
     try:
         with open(progname) as fp:
             code = compile(fp.read(), progname, 'exec')
@@ -120,7 +120,8 @@ def main(argv=None):
         call_stack_string += elem
     _err_exit(
         "Someone called scorep.__main__.main(argv).\n"
-        "This is not supposed to happen, but might be triggered, if your application calls \"sys.modules['__main__'].main\".\n"
+        "This is not supposed to happen, but might be triggered, "
+        "if your application calls \"sys.modules['__main__'].main\".\n"
         "This python stacktrace might be helpfull to find the reason:\n%s" %
         call_stack_string)
 

--- a/scorep/instrumenter.py
+++ b/scorep/instrumenter.py
@@ -8,16 +8,16 @@ import os
 global_instrumenter = None
 
 
-def get_instrumenter(
-        bindings=None,
-        enable_instrumenter=False,
-        instrumenter_type="dummy"):
+def get_instrumenter(bindings=None,
+                     enable_instrumenter=False,
+                     instrumenter_type="dummy"):
     """
     returns an instrumenter
 
     @param bindings the c/c++ scorep bindings
     @param enable_instrumenter True if the Instrumenter should be enabled when run is called
-    @param instrumenter_type which python tracing interface to use. Currently available: `profile` (default), `trace` and `dummy`
+    @param instrumenter_type which python tracing interface to use.
+           Currently available: `profile` (default), `trace` and `dummy`
     """
     global global_instrumenter
     if global_instrumenter is None:
@@ -47,7 +47,8 @@ def register():
 def unregister():
     """
     Disables the python-tracing.
-    Disabling the python-tracing is more efficient than disable_recording, as python does not longer call the tracing module.
+    Disabling the python-tracing is more efficient than disable_recording,
+    as python does not longer call the tracing module.
     However, all the other things that are traced by Score-P will still be recorded.
     Please call register() to enable tracing again.
     """
@@ -62,14 +63,14 @@ class enable():
         do stuff
     ```
     This overides --no-instrumenter (--nopython leagacy)
-    @param region_name: if a region name is given, the region the contextmanager is active will be marked in the trace or profile
+    If a region name is given, the region the contextmanager is active will be marked in the trace or profile
     """
-
     def __init__(self, region_name=None):
         self.region_name = region_name
 
     def __enter__(self):
-        self.tracer_registered = scorep.instrumenter.get_instrumenter().get_registered()
+        self.tracer_registered = scorep.instrumenter.get_instrumenter(
+        ).get_registered()
         if not self.tracer_registered:
             if self.region_name:
                 self.module_name = "user_instrumenter"
@@ -82,7 +83,8 @@ class enable():
                     full_file_name = "None"
 
                 scorep.instrumenter.get_instrumenter().region_begin(
-                    self.module_name, self.region_name, full_file_name, line_number)
+                    self.module_name, self.region_name, full_file_name,
+                    line_number)
 
             scorep.instrumenter.get_instrumenter().register()
 
@@ -103,14 +105,14 @@ class disable():
         do stuff
     ```
     This overides --no-instrumenter (--nopython leagacy)
-    @param region_name: if a region name is given, the region the contextmanager is active will be marked in the trace or profile
+    If a region name is given, the region the contextmanager is active will be marked in the trace or profile
     """
-
     def __init__(self, region_name=None):
         self.region_name = region_name
 
     def __enter__(self):
-        self.tracer_registered = scorep.instrumenter.get_instrumenter().get_registered()
+        self.tracer_registered = scorep.instrumenter.get_instrumenter(
+        ).get_registered()
         if self.tracer_registered:
             scorep.instrumenter.get_instrumenter().unregister()
 
@@ -125,7 +127,8 @@ class disable():
                     full_file_name = "None"
 
                 scorep.instrumenter.get_instrumenter().region_begin(
-                    self.module_name, self.region_name, full_file_name, line_number)
+                    self.module_name, self.region_name, full_file_name,
+                    line_number)
 
     def __exit__(self, exc_type, exc_value, traceback):
         if self.tracer_registered:

--- a/scorep/instrumenters/dummy.py
+++ b/scorep/instrumenters/dummy.py
@@ -2,6 +2,7 @@ __all__ = ['ScorepDummy']
 
 import scorep.instrumenters.base_instrumenter as base_instrumenter
 
+
 class ScorepDummy(base_instrumenter.BaseInstrumenter):
     def __init__(self, scorep_bindings=None, enable_instrumenter=True):
         pass

--- a/test/test.py
+++ b/test/test.py
@@ -298,7 +298,6 @@ class TestScorepBindingsPython(unittest.TestCase):
 
         env = self.env
         env["SCOREP_EXPERIMENT_DIRECTORY"] += "/test_mpi"
-        trace_path = env["SCOREP_EXPERIMENT_DIRECTORY"] + "/traces.otf2"
         out = call(["mpirun",
                     "-n",
                     "2",
@@ -316,19 +315,15 @@ class TestScorepBindingsPython(unittest.TestCase):
         std_out = out[1]
         std_err = out[2]
 
-        expected_std_err = ""
-        expected_std_out = u"\[0[0-9]\] \[0. 1. 2. 3. 4.\]\\n\[0[0-9]] \[0. 1. 2. 3. 4.\]\\n"
+        expected_std_out = r"\[0[0-9]\] \[0. 1. 2. 3. 4.\]\n\[0[0-9]] \[0. 1. 2. 3. 4.\]\n"
 
         self.assertRegex(std_err,
-                         '\[Score-P\] [\w/.: ]*MPI_THREAD_FUNNELED')
+                         r'\[Score-P\] [\w/.: ]*MPI_THREAD_FUNNELED')
         self.assertRegex(std_out, expected_std_out)
-
-        expected_std_out
 
     def test_call_main(self):
         env = self.env
         env["SCOREP_EXPERIMENT_DIRECTORY"] += "/test_call_main"
-        trace_path = env["SCOREP_EXPERIMENT_DIRECTORY"] + "/traces.otf2"
         out = call([self.python,
                     "-m",
                     "scorep",
@@ -346,7 +341,6 @@ class TestScorepBindingsPython(unittest.TestCase):
     def test_dummy(self):
         env = self.env
         env["SCOREP_EXPERIMENT_DIRECTORY"] += "/test_dummy"
-        trace_path = env["SCOREP_EXPERIMENT_DIRECTORY"] + "/traces.otf2"
 
         out = call([self.python,
                     "-m",
@@ -382,7 +376,6 @@ class TestScorepBindingsPython(unittest.TestCase):
 
         self.assertEqual(std_out, "[[ 7 10]\n [15 22]]\n")
         self.assertEqual(std_err, self.expected_std_err)
-        
 
         out = call(["otf2-print", trace_path])
         std_out = out[1]
@@ -393,7 +386,6 @@ class TestScorepBindingsPython(unittest.TestCase):
                          'ENTER[ ]*[0-9 ]*[0-9 ]*Region: "numpy.__array_function__:dot"')
         self.assertRegex(std_out,
                          'LEAVE[ ]*[0-9 ]*[0-9 ]*Region: "numpy.__array_function__:dot"')
-
 
     def tearDown(self):
         # pass

--- a/test/test_instrumentation.py
+++ b/test/test_instrumentation.py
@@ -6,4 +6,5 @@ def foo():
     test_instrumentation2.baz()
     test_instrumentation2.bar()
 
+
 foo()

--- a/test/test_numpy_dot.py
+++ b/test/test_numpy_dot.py
@@ -2,8 +2,8 @@ import numpy
 import scorep.instrumenter
 
 with scorep.instrumenter.enable():
-    a = [[1, 2],[3, 4]] 
-    b = [[1, 2],[3, 4]]
-    
-    c = numpy.dot(a,b)
+    a = [[1, 2], [3, 4]]
+    b = [[1, 2], [3, 4]]
+
+    c = numpy.dot(a, b)
     print(c)

--- a/test/test_user_instrumentation.py
+++ b/test/test_user_instrumentation.py
@@ -7,5 +7,6 @@ def foo():
     test_instrumentation2.baz()
     test_instrumentation2.bar()
 
+
 with scorep.instrumenter.enable():
     foo()


### PR DESCRIPTION
This makes `flake8` pass.

The renaming of the config file is so it is automatically recognized by autopep8 and flake8. Another (maybe better) solution is to rename to `setup.cfg` which also works with both tools.

Most of the issues have been fixed by running autopep8. The remainder has been manually fixed

For reference the found issues are:

```
benchmark/benchmark_helper.py:43:18: E211 whitespace before '('
benchmark/benchmark.py:13:7: E225 missing whitespace around operator
benchmark/benchmark.py:14:20: E225 missing whitespace around operator
benchmark/benchmark.py:15:20: E225 missing whitespace around operator
benchmark/benchmark.py:15:71: W291 trailing whitespace
benchmark/benchmark.py:21:12: F632 use ==/!= to compare constant literals (str, bytes, int, float, tuple)
scorep/__main__.py:123:121: E501 line too long (127 > 120 characters)
scorep/__init__.py:2:1: F401 'scorep.instrumenter' imported but unused
scorep/instrumenter.py:20:121: E501 line too long (129 > 120 characters)
scorep/instrumenter.py:50:121: E501 line too long (125 > 120 characters)
scorep/instrumenter.py:65:121: E501 line too long (129 > 120 characters)
scorep/instrumenter.py:106:121: E501 line too long (129 > 120 characters)
scorep/instrumenters/dummy.py:5:1: E302 expected 2 blank lines, found 1
test/test.py:301:9: F841 local variable 'trace_path' is assigned to but never used
test/test.py:319:9: F841 local variable 'expected_std_err' is assigned to but never used
test/test.py:320:30: W605 invalid escape sequence '\['
test/test.py:320:38: W605 invalid escape sequence '\]'
test/test.py:320:41: W605 invalid escape sequence '\['
test/test.py:320:57: W605 invalid escape sequence '\]'
test/test.py:320:62: W605 invalid escape sequence '\['
test/test.py:320:72: W605 invalid escape sequence '\['
test/test.py:320:88: W605 invalid escape sequence '\]'
test/test.py:323:27: W605 invalid escape sequence '\['
test/test.py:323:36: W605 invalid escape sequence '\]'
test/test.py:323:40: W605 invalid escape sequence '\w'
test/test.py:331:9: F841 local variable 'trace_path' is assigned to but never used
test/test.py:349:9: F841 local variable 'trace_path' is assigned to but never used
test/test.py:385:1: W293 blank line contains whitespace
test/test.py:387:9: E303 too many blank lines (2)
test/test.py:398:5: E303 too many blank lines (2)
test/test_user_instrumentation.py:10:1: E305 expected 2 blank lines after class or function definition, found 1
test/test_instrumentation.py:9:1: E305 expected 2 blank lines after class or function definition, found 1
test/test_numpy_dot.py:5:16: E231 missing whitespace after ','
test/test_numpy_dot.py:5:24: W291 trailing whitespace
test/test_numpy_dot.py:6:16: E231 missing whitespace after ','
test/test_numpy_dot.py:7:1: W293 blank line contains whitespace
test/test_numpy_dot.py:8:20: E231 missing whitespace after ','
test/test_numpy_dot.py:9:13: W292 no newline at end of file
```
