### PR TITLE
Run test with default python cmd

### DIFF
--- a/test/test.py
+++ b/test/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import unittest
 import subprocess


### PR DESCRIPTION
The test is not written specifically for python3 but for any python version, hence it should respect the currently active `python` which might be set by e.g. pyenv to python3 or python2.