### PR TITLE
Enhance CMake build system and add developer readme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,14 @@ find_package(Python REQUIRED COMPONENTS Interpreter Development)
 Python_add_library(scorep_bindings src/scorep.cpp)
 target_link_libraries(scorep_bindings PRIVATE Scorep::Scorep)
 target_compile_features(scorep_bindings PRIVATE cxx_std_11)
+set_target_properties(scorep_bindings PROPERTIES
+  LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/site-packages/scorep
+)
+add_custom_target(ScorepModule ALL
+  ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_LIST_DIR}/scorep $<TARGET_FILE_DIR:scorep_bindings>
+  COMMENT "Copying module files to build tree"
+)
+
 
 set(INSTALL_DIR "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,16 @@ add_custom_target(ScorepModule ALL
   COMMENT "Copying module files to build tree"
 )
 
+enable_testing()
+add_test(NAME ScorepPythonTests
+         COMMAND Python::Interpreter test.py
+         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/test
+)
+set(pythonPath ${CMAKE_CURRENT_BINARY_DIR}/site-packages)
+if(ENV{PYTHONPATH})
+  string(PREPEND pythonPath "$ENV{PYTHONPATH}:")
+endif()
+set_tests_properties(ScorepPythonTests PROPERTIES ENVIRONMENT "PYTHONPATH=${pythonPath}")
 
 set(INSTALL_DIR "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,23 +1,26 @@
 # Developing
+We appreciate any contributions to the Score-P Python Bindings.
+However, there are a few policies we agreed on and which are relevant for contributions.
+These are detailed below. 
 
-## Formatting / Codestyle
+## Fromatting / Codestyle
 
-C/C++ code must be formatted by clang-format-9 according to the .clang-format file.   
-Python code must pass flake8 checks as defined in the .flake8 file.
-
-Besides that being consistent and readable is key.
+Readable and consistent code makes it easy to understand your changes.
+Therefore the GitHub CI system has checks using `clang-format-9` and `flake8` in place.
+Please make sure that these test pass, before making a Pull Request.
+If you do not use the GitHub CI process, you can use the provided `.flake8` and `.clang-format` files, to check your code manually.
 
 ## Build system
 
-The only officially supported way to install this module is by `pip`.
+The official way to build and install this module is using `pip`.
+Please make sure that all changes, you introduce, work with `pip install .`.
 
-However there exists a semi-supported CMake-based build system suitable for development.
-No issues against that are allowed but PRs fixing it in case of problems are welcome.
-This build system is especially suitable for development as e.g. include paths for C++ are correctly searched for and set up for use by IDEs or other tools.
-For example it works well with Visual Studio Code given the approriate extensions (C++, Python, CMake) are installed, see their documentation for details.
+However, you might have noted that there is a CMake-based build system in place as well.
+We do not support this build system, and it might be outdated or buggy.
+Thorough, we do not actively maintain the CMake Buildsystem, and will not help you fix issues to that build system, Pull Requests against it might be accepted.
 
-The CMake build system creates a folder `site-packages` in the build folder where the C/C++ extension module and the `scorep` module are copied to on each build (e.g. `make`-call).
-It is hence possible to add that folder to the `PYTHONPATH` environment variable, build the project and start debugging or execute the tests in `test/test.py`.
+You might find this build system helpful for development, especially if you are doing C/C++ things:
+* Include paths for C++ are correctly searched for and set up for use by IDEs or other tools. For example, Visual Studio Code, given the appropriate extensions (C++, Python, CMake)
+* Creates a folder site-packages in the build folder where the C/C++ extension module and the scorep module are copied to on each build (e.g. make-call). Hence it is possible to add that folder to the PYTHONPATH environment variable, build the project and start debugging or execute the tests in test/test.py.
 
-Note that changes to the Python source files are not reflected in that folder unless a build is executed.
-Also when deleting Python files it is recommended to clear and recreate the build folder.
+Please note, that changes to the Python source files are not reflected in that folder unless a build is executed. Also, if you delete Python files, we recommended to clear and recreate the build folder.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,23 @@
+# Developing
+
+## Formatting / Codestyle
+
+C/C++ code must be formatted by clang-format-9 according to the .clang-format file.   
+Python code must pass flake8 checks as defined in the .flake8 file.
+
+Besides that being consistent and readable is key.
+
+## Build system
+
+The only officially supported way to install this module is by `pip`.
+
+However there exists a semi-supported CMake-based build system suitable for development.
+No issues against that are allowed but PRs fixing it in case of problems are welcome.
+This build system is especially suitable for development as e.g. include paths for C++ are correctly searched for and set up for use by IDEs or other tools.
+For example it works well with Visual Studio Code given the approriate extensions (C++, Python, CMake) are installed, see their documentation for details.
+
+The CMake build system creates a folder `site-packages` in the build folder where the C/C++ extension module and the `scorep` module are copied to on each build (e.g. `make`-call).
+It is hence possible to add that folder to the `PYTHONPATH` environment variable, build the project and start debugging or execute the tests in `test/test.py`.
+
+Note that changes to the Python source files are not reflected in that folder unless a build is executed.
+Also when deleting Python files it is recommended to clear and recreate the build folder.

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -3,24 +3,27 @@ We appreciate any contributions to the Score-P Python Bindings.
 However, there are a few policies we agreed on and which are relevant for contributions.
 These are detailed below. 
 
-## Fromatting / Codestyle
+## Formatting / Codestyle
 
 Readable and consistent code makes it easy to understand your changes.
-Therefore the GitHub CI system has checks using `clang-format-9` and `flake8` in place.
-Please make sure that these test pass, before making a Pull Request.
-If you do not use the GitHub CI process, you can use the provided `.flake8` and `.clang-format` files, to check your code manually.
+Therefore the CI system has checks using `clang-format-9` and `flake8` in place.
+Please make sure that these test pass, when making a Pull Request.
+These tests will tell you the issues and often also how to fix them.
+Prior to opening a Pull Request you can use the provided `.flake8` and `.clang-format` files, to check your code locally and run `clang-format-9` or `autopep8` to fix most of them automatically.
 
 ## Build system
 
 The official way to build and install this module is using `pip`.
 Please make sure that all changes, you introduce, work with `pip install .`.
 
-However, you might have noted that there is a CMake-based build system in place as well.
+However, you might have noticed that there is a CMake-based build system in place as well.
 We do not support this build system, and it might be outdated or buggy.
-Thorough, we do not actively maintain the CMake Buildsystem, and will not help you fix issues to that build system, Pull Requests against it might be accepted.
+Although, we do not actively maintain the CMake build system, and will not help you fix issues related to it, Pull Requests against it might be accepted.
 
 You might find this build system helpful for development, especially if you are doing C/C++ things:
-* Include paths for C++ are correctly searched for and set up for use by IDEs or other tools. For example, Visual Studio Code, given the appropriate extensions (C++, Python, CMake)
-* Creates a folder site-packages in the build folder where the C/C++ extension module and the scorep module are copied to on each build (e.g. make-call). Hence it is possible to add that folder to the PYTHONPATH environment variable, build the project and start debugging or execute the tests in test/test.py.
+* Include paths for C++ are correctly searched for and set up for use by IDEs or other tools. For example Visual Studio Code works out of the box, given the appropriate extensions (C++, Python, CMake) are installed.
+* A folder `site-packages` is created in the build folder where the C/C++ extension module and the scorep module are copied to on each build (e.g. `make`-call). Hence it is possible to add that folder to the PYTHONPATH environment variable, build the project and start debugging or execute the tests in test/test.py.
+* A `test` target exists which can be run to execute all tests.
 
-Please note, that changes to the Python source files are not reflected in that folder unless a build is executed. Also, if you delete Python files, we recommended to clear and recreate the build folder.
+Please note, that changes to the Python source files are not reflected in the build folder unless a build is executed.
+Also, if you delete Python files, we recommended to clear and recreate the build folder.


### PR DESCRIPTION
A minor enhancement of the CMake build system which helps me a lot: Create a full module tree in the build folder combining the C-extension and the Python files so you can directly debug it without having to install it.

I added a `DEVELOPING.md` file to start gathering some information useful for developers in a commonly known place. There the CMake build system is described including setup hints with a clear disclaimer that it is not officially supported

As code is better than documentation I added `make test` support to CMake. The `if`-clause is to avoid having `PYTHONPATH=:foobar` (empty entry) which may or may not cause problems. Besides that I find that a perfectly readable example on how to setup the developers environment and it can be used by `make test` to quickly verify that all tests pass.