### PR TITLE
Collapse all run functions into 1

### DIFF
--- a/scorep/__main__.py
+++ b/scorep/__main__.py
@@ -104,7 +104,7 @@ def scorep_main(argv=None):
             '__cached__': None,
         }
 
-        tracer.runctx(code, globs, globs)
+        tracer.run(code, globs, globs)
     except OSError as err:
         _err_exit("Cannot run file %r because: %s" % (sys.argv[0], err))
     finally:

--- a/scorep/instrumenters/base_instrumenter.py
+++ b/scorep/instrumenters/base_instrumenter.py
@@ -48,15 +48,7 @@ class BaseInstrumenter(_BaseInstrumenter):
         return None
 
     @abc.abstractmethod
-    def run(self, cmd):
-        pass
-
-    @abc.abstractmethod
-    def runctx(self, cmd, globals=None, locals=None):
-        pass
-
-    @abc.abstractmethod
-    def runfunc(self, func, *args, **kw):
+    def run(self, cmd, globals=None, locals=None):
         pass
 
     @abc.abstractmethod

--- a/scorep/instrumenters/dummy.py
+++ b/scorep/instrumenters/dummy.py
@@ -16,18 +16,12 @@ class ScorepDummy(base_instrumenter.BaseInstrumenter):
     def get_registered(self):
         return None
 
-    def run(self, cmd):
-        pass
-
-    def runctx(self, cmd, globals=None, locals=None):
+    def run(self, cmd, globals=None, locals=None):
         if globals is None:
             globals = {}
         if locals is None:
             locals = {}
         exec(cmd, globals, locals)
-
-    def runfunc(self, func, *args, **kw):
-        pass
 
     def region_begin(self, module_name, function_name, file_name, line_number):
         pass

--- a/scorep/instrumenters/scorep_profile.py
+++ b/scorep/instrumenters/scorep_profile.py
@@ -48,10 +48,7 @@ class ScorepProfile(base_instrumenter.BaseInstrumenter):
     def get_registered(self):
         return self.tracer_registered
 
-    def run(self, cmd):
-        self.runctx(cmd)
-
-    def runctx(self, cmd, globals=None, locals=None):
+    def run(self, cmd, globals=None, locals=None):
         if globals is None:
             globals = {}
         if locals is None:
@@ -62,16 +59,6 @@ class ScorepProfile(base_instrumenter.BaseInstrumenter):
             exec(cmd, globals, locals)
         finally:
             self.unregister()
-
-    def runfunc(self, func, *args, **kw):
-        result = None
-        if self.enable_instrumenter:
-            self.register()
-        try:
-            result = func(*args, **kw)
-        finally:
-            self.unregister()
-        return result
 
     def globaltrace_lt(self, frame, why, arg):
         """Handler for call events.

--- a/scorep/instrumenters/scorep_trace.py
+++ b/scorep/instrumenters/scorep_trace.py
@@ -49,10 +49,7 @@ class ScorepTrace(base_instrumenter.BaseInstrumenter):
     def get_registered(self):
         return self.tracer_registered
 
-    def run(self, cmd):
-        self.runctx(cmd)
-
-    def runctx(self, cmd, globals=None, locals=None):
+    def run(self, cmd, globals=None, locals=None):
         if globals is None:
             globals = {}
         if locals is None:
@@ -63,16 +60,6 @@ class ScorepTrace(base_instrumenter.BaseInstrumenter):
             exec(cmd, globals, locals)
         finally:
             self.unregister()
-
-    def runfunc(self, func, *args, **kw):
-        result = None
-        if self.enable_instrumenter:
-            self.register()
-        try:
-            result = func(*args, **kw)
-        finally:
-            self.unregister()
-        return result
 
     def globaltrace_lt(self, frame, why, arg):
         """Handler for call events.


### PR DESCRIPTION
As discussed this removes `runfunc` and renames `runctx` to `run` (the current `run` and `runctx` functions were basically identical)

Fixes #76