### PR TITLE
Directly import C extension

### DIFF
--- a/scorep/__main__.py
+++ b/scorep/__main__.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import importlib
 
 import scorep.instrumenter
 import scorep.subsystem
@@ -83,15 +82,12 @@ def scorep_main(argv=None):
     else:
         scorep.subsystem.reset_pereload()
 
-    scorep_bindings = importlib.import_module("scorep.scorep_bindings")
-
     # everything is ready
     sys.argv = prog_argv
     progname = prog_argv[0]
     sys.path[0] = os.path.split(progname)[0]
 
-    tracer = scorep.instrumenter.get_instrumenter(scorep_bindings,
-                                                  not no_instrumenter,
+    tracer = scorep.instrumenter.get_instrumenter(not no_instrumenter,
                                                   instrumenter_type)
     try:
         with open(progname) as fp:

--- a/scorep/instrumenters/dummy.py
+++ b/scorep/instrumenters/dummy.py
@@ -4,7 +4,7 @@ import scorep.instrumenters.base_instrumenter as base_instrumenter
 
 
 class ScorepDummy(base_instrumenter.BaseInstrumenter):
-    def __init__(self, scorep_bindings=None, enable_instrumenter=True):
+    def __init__(self, enable_instrumenter=True):
         pass
 
     def register(self):

--- a/scorep/instrumenters/scorep_instrumenter.py
+++ b/scorep/instrumenters/scorep_instrumenter.py
@@ -2,17 +2,17 @@ import abc
 import inspect
 import os
 from scorep.instrumenters import base_instrumenter
+from scorep import scorep_bindings
 
 
 class ScorepInstrumenter(base_instrumenter.BaseInstrumenter):
     """Base class for all instrumenters using Score-P"""
 
-    def __init__(self, scorep_bindings, enable_instrumenter=True):
+    def __init__(self, enable_instrumenter=True):
         """
         @param enable_instrumenter true if the tracing shall be initialised.
             Please note, that it is still possible to enable the tracing later using register()
         """
-        self._scorep_bindings = scorep_bindings
         self._tracer_registered = False
         self._enabled = enable_instrumenter
 
@@ -58,12 +58,12 @@ class ScorepInstrumenter(base_instrumenter.BaseInstrumenter):
 
     def region_begin(self, module_name, function_name, file_name, line_number):
         """Record a region begin event"""
-        self._scorep_bindings.region_begin(
+        scorep_bindings.region_begin(
             module_name, function_name, file_name, line_number)
 
     def region_end(self, module_name, function_name):
         """Record a region end event"""
-        self._scorep_bindings.region_end(module_name, function_name)
+        scorep_bindings.region_end(module_name, function_name)
 
     def rewind_begin(self, name, file_name=None, line_number=None):
         """
@@ -82,7 +82,7 @@ class ScorepInstrumenter(base_instrumenter.BaseInstrumenter):
         else:
             full_file_name = "None"
 
-        self._scorep_bindings.rewind_begin(name, full_file_name, line_number)
+        scorep_bindings.rewind_begin(name, full_file_name, line_number)
 
     def rewind_end(self, name, value):
         """
@@ -90,7 +90,7 @@ class ScorepInstrumenter(base_instrumenter.BaseInstrumenter):
         @param name name of the user region
         @param value True or False, whenether the region shall be rewinded or not.
         """
-        self._scorep_bindings.rewind_end(name, value)
+        scorep_bindings.rewind_end(name, value)
 
     def oa_region_begin(self, name, file_name=None, line_number=None):
         """
@@ -109,28 +109,28 @@ class ScorepInstrumenter(base_instrumenter.BaseInstrumenter):
         else:
             full_file_name = "None"
 
-        self._scorep_bindings.oa_region_begin(name, full_file_name, line_number)
+        scorep_bindings.oa_region_begin(name, full_file_name, line_number)
 
     def oa_region_end(self, name):
         """End an Online Access region."""
-        self._scorep_bindings.oa_region_end(name)
+        scorep_bindings.oa_region_end(name)
 
     def user_enable_recording(self):
         """Enable writing of trace events in ScoreP"""
-        self._scorep_bindings.enable_recording()
+        scorep_bindings.enable_recording()
 
     def user_disable_recording(self):
         """Disable writing of trace events in ScoreP"""
-        self._scorep_bindings.disable_recording()
+        scorep_bindings.disable_recording()
 
     def user_parameter_int(self, name, val):
         """Record a parameter of type integer"""
-        self._scorep_bindings.parameter_int(name, val)
+        scorep_bindings.parameter_int(name, val)
 
     def user_parameter_uint(self, name, val):
         """Record a parameter of type unsigned integer"""
-        self._scorep_bindings.parameter_string(name, val)
+        scorep_bindings.parameter_string(name, val)
 
     def user_parameter_string(self, name, string):
         """Record a parameter of type string"""
-        self._scorep_bindings.parameter_string(name, string)
+        scorep_bindings.parameter_string(name, string)

--- a/scorep/instrumenters/scorep_profile.py
+++ b/scorep/instrumenters/scorep_profile.py
@@ -3,6 +3,7 @@ __all__ = ['ScorepProfile']
 import sys
 from scorep.instrumenters.utils import get_module_name, get_file_name
 from scorep.instrumenters.scorep_instrumenter import ScorepInstrumenter
+from scorep import scorep_bindings
 
 try:
     import threading
@@ -41,9 +42,9 @@ class ScorepProfile(ScorepInstrumenter):
             if not code.co_name == "_unsetprofile" and not modulename[:6] == "scorep":
                 full_file_name = get_file_name(frame)
                 line_number = code.co_firstlineno
-                self._scorep_bindings.region_begin(modulename, code.co_name, full_file_name, line_number)
+                scorep_bindings.region_begin(modulename, code.co_name, full_file_name, line_number)
         elif why == 'return':
             code = frame.f_code
             modulename = get_module_name(frame)
             if not code.co_name == "_unsetprofile" and not modulename[:6] == "scorep":
-                self._scorep_bindings.region_end(modulename, code.co_name)
+                scorep_bindings.region_end(modulename, code.co_name)

--- a/scorep/instrumenters/scorep_trace.py
+++ b/scorep/instrumenters/scorep_trace.py
@@ -3,6 +3,7 @@ __all__ = ['ScorepTrace']
 import sys
 from scorep.instrumenters.utils import get_module_name, get_file_name
 from scorep.instrumenters.scorep_instrumenter import ScorepInstrumenter
+from scorep import scorep_bindings
 
 try:
     import threading
@@ -39,7 +40,7 @@ class ScorepTrace(ScorepInstrumenter):
             if not code.co_name == "_unsettrace" and not modulename[:6] == "scorep":
                 full_file_name = get_file_name(frame)
                 line_number = code.co_firstlineno
-                self._scorep_bindings.region_begin(modulename, code.co_name, full_file_name, line_number)
+                scorep_bindings.region_begin(modulename, code.co_name, full_file_name, line_number)
                 return self._localtrace
         return None
 
@@ -47,5 +48,5 @@ class ScorepTrace(ScorepInstrumenter):
         if why == 'return':
             code = frame.f_code
             modulename = get_module_name(frame)
-            self._scorep_bindings.region_end(modulename, code.co_name)
+            scorep_bindings.region_end(modulename, code.co_name)
         return self._localtrace


### PR DESCRIPTION
Closes #79

As described in the above issue this directly imports the C extension where it is needed.

It is not possible anymore to import the instrumenter in user code, but as the instrumenter module is private (should be) this should be fine.   
The imports had to be moved to the place where the instrumenters are instantiated for the same reason. This leads to `scorep.instrumenter.get_instrumenter` causing an "unknown module 'scorep'" error as it is no longer imported. But that function is defined in the same file and can be used directly.

Side note: Previously the `enable_instrumenter` was passed to the parameter `scorep_bindings` of the `Dummy` constructor which was a mistake but with no effect as it wasn't used.