### PR TITLE
Use pytest on CI and prepare switch to full pytest style tests

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -47,10 +47,10 @@ jobs:
     - name: Install Python packages
       run: |
         pip install --upgrade pip
-        pip install numpy mpi4py
+        pip install numpy mpi4py pytest
 
     - name: Build python bindings
       run: pip install .
     - name: Run tests
       working-directory: test
-      run: ./test_scorep.py
+      run: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 dist: bionic
 
 language: python
+cache: pip
 python:
  - "2.7"
  - "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
         - libopenmpi-dev
  
 install:
-  - pip install mpi4py numpy
+  - pip install mpi4py numpy pytest
 
 script:
-  - pip install ./ && cd test && python test_scorep.py
+  - pip install ./ && cd test && pytest

--- a/test/test_scorep.py
+++ b/test/test_scorep.py
@@ -53,8 +53,6 @@ class TestScorepBindingsPython(unittest.TestCase):
         self.env["SCOREP_TOTAL_MEMORY"] = "3G"
         self.env["SCOREP_EXPERIMENT_DIRECTORY"] = "test_bindings_dir"
 
-        self.expected_std_err = ""
-
         shutil.rmtree(
             self.env["SCOREP_EXPERIMENT_DIRECTORY"],
             ignore_errors=True)
@@ -78,7 +76,7 @@ class TestScorepBindingsPython(unittest.TestCase):
         std_out = out[1]
         std_err = out[2]
 
-        self.assertEqual(std_err, self.expected_std_err)
+        self.assertEqual(std_err, "")
         self.assertEqual(
             std_out,
             "hello world\nhello world\nhello world3\nhello world4\n")
@@ -118,7 +116,7 @@ class TestScorepBindingsPython(unittest.TestCase):
         std_out = out[1]
         std_err = out[2]
 
-        self.assertEqual(std_err, self.expected_std_err)
+        self.assertEqual(std_err, "")
         self.assertEqual(std_out, "hello world\nhello world\nhello world\n")
 
         out = call(["otf2-print", trace_path])
@@ -144,7 +142,7 @@ class TestScorepBindingsPython(unittest.TestCase):
         std_out = out[1]
         std_err = out[2]
 
-        self.assertEqual(std_err, self.expected_std_err)
+        self.assertEqual(std_err, "")
         self.assertEqual(
             std_out,
             "hello world\nhello world\nhello world3\nhello world4\n")
@@ -162,7 +160,7 @@ class TestScorepBindingsPython(unittest.TestCase):
         std_out = out[1]
         std_err = out[2]
 
-        self.assertEqual(std_err, self.expected_std_err)
+        self.assertEqual(std_err, "")
         self.assertEqual(std_out, "hello world\nhello world\n")
 
         out = call(["otf2-print", trace_path])
@@ -188,7 +186,7 @@ class TestScorepBindingsPython(unittest.TestCase):
         std_out = out[1]
         std_err = out[2]
 
-        self.assertEqual(std_err, self.expected_std_err)
+        self.assertEqual(std_err, "")
         self.assertEqual(std_out, "hello world\n")
 
         out = call(["otf2-print", trace_path])
@@ -215,7 +213,7 @@ class TestScorepBindingsPython(unittest.TestCase):
         std_out = out[1]
         std_err = out[2]
 
-        self.assertEqual(std_err, self.expected_std_err)
+        self.assertEqual(std_err, "")
         self.assertEqual(std_out, "hello world\nbaz\nbar\n")
 
         out = call(["otf2-print", trace_path])
@@ -243,7 +241,7 @@ class TestScorepBindingsPython(unittest.TestCase):
         std_out = out[1]
         std_err = out[2]
 
-        self.assertEqual(std_err, self.expected_std_err)
+        self.assertEqual(std_err, "")
         self.assertEqual(std_out, "hello world\nbaz\nbar\n")
 
         out = call(["otf2-print", trace_path])
@@ -355,7 +353,7 @@ class TestScorepBindingsPython(unittest.TestCase):
         std_out = out[1]
         std_err = out[2]
 
-        self.assertEqual(std_err, self.expected_std_err)
+        self.assertEqual(std_err, "")
         self.assertEqual(std_out, "hello world\nbaz\nbar\n")
         self.assertTrue(
             os.path.exists(
@@ -379,7 +377,7 @@ class TestScorepBindingsPython(unittest.TestCase):
         std_err = out[2]
 
         self.assertEqual(std_out, "[[ 7 10]\n [15 22]]\n")
-        self.assertEqual(std_err, self.expected_std_err)
+        self.assertEqual(std_err, "")
 
         out = call(["otf2-print", trace_path])
         std_out = out[1]

--- a/test/test_scorep.py
+++ b/test/test_scorep.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env pytest
 
 import unittest
 import subprocess
@@ -35,10 +35,21 @@ def call(arguments, env=os.environ.copy()):
     return result
 
 
-class TestScorepBindingsPython(unittest.TestCase):
-    maxDiff = None
-    python = sys.executable
+def call_with_scorep(file, scorep_arguments=None, env=None):
+    """
+    Shortcut for running a python file with the scorep module
 
+    @return triple (returncode, stdout, stderr) from the call to subprocess
+    """
+    arguments = [sys.executable, "-m", "scorep"]
+    if scorep_arguments:
+        arguments.extend(scorep_arguments)
+    if env is None:
+        env = os.environ
+    return call(arguments + [file], env=env)
+
+
+class TestScorepBindingsPython(unittest.TestCase):
     def assertRegex(self, in1, in2):
         if sys.version_info > (3, 5):
             super().assertRegex(in1, in2)
@@ -67,12 +78,9 @@ class TestScorepBindingsPython(unittest.TestCase):
         env["SCOREP_EXPERIMENT_DIRECTORY"] += "/test_user_regions"
         trace_path = env["SCOREP_EXPERIMENT_DIRECTORY"] + "/traces.otf2"
 
-        out = call([self.python,
-                    "-m",
-                    "scorep",
-                    "--nopython",
-                    "cases/user_regions.py"],
-                   env=env)
+        out = call_with_scorep("cases/user_regions.py",
+                               ["--nopython"],
+                               env=env)
         std_out = out[1]
         std_err = out[2]
 
@@ -107,12 +115,9 @@ class TestScorepBindingsPython(unittest.TestCase):
         env["SCOREP_EXPERIMENT_DIRECTORY"] += "/test_context"
         trace_path = env["SCOREP_EXPERIMENT_DIRECTORY"] + "/traces.otf2"
 
-        out = call([self.python,
-                    "-m",
-                    "scorep",
-                    "--noinstrumenter",
-                    "cases/context.py"],
-                   env=env)
+        out = call_with_scorep("cases/context.py",
+                               ["--noinstrumenter"],
+                               env=env)
         std_out = out[1]
         std_err = out[2]
 
@@ -136,7 +141,7 @@ class TestScorepBindingsPython(unittest.TestCase):
         env = self.env
         env["SCOREP_EXPERIMENT_DIRECTORY"] += "/test_user_regions_no_scorep"
 
-        out = call([self.python,
+        out = call([sys.executable,
                     "cases/user_regions.py"],
                    env=env)
         std_out = out[1]
@@ -152,11 +157,7 @@ class TestScorepBindingsPython(unittest.TestCase):
         env["SCOREP_EXPERIMENT_DIRECTORY"] += "/test_user_rewind"
         trace_path = env["SCOREP_EXPERIMENT_DIRECTORY"] + "/traces.otf2"
 
-        out = call([self.python,
-                    "-m",
-                    "scorep",
-                    "cases/user_rewind.py"],
-                   env=env)
+        out = call_with_scorep("cases/user_rewind.py", env=env)
         std_out = out[1]
         std_err = out[2]
 
@@ -177,12 +178,9 @@ class TestScorepBindingsPython(unittest.TestCase):
         env["SCOREP_EXPERIMENT_DIRECTORY"] += "/test_oa_regions"
         trace_path = env["SCOREP_EXPERIMENT_DIRECTORY"] + "/traces.otf2"
 
-        out = call([self.python,
-                    "-m",
-                    "scorep",
-                    "--nopython",
-                    "cases/oa_regions.py"],
-                   env=env)
+        out = call_with_scorep("cases/oa_regions.py",
+                               ["--nopython"],
+                               env=env)
         std_out = out[1]
         std_err = out[2]
 
@@ -204,12 +202,9 @@ class TestScorepBindingsPython(unittest.TestCase):
         env["SCOREP_EXPERIMENT_DIRECTORY"] += "/test_instrumentation"
         trace_path = env["SCOREP_EXPERIMENT_DIRECTORY"] + "/traces.otf2"
 
-        out = call([self.python,
-                    "-m",
-                    "scorep",
-                    "--nocompiler",
-                    "cases/instrumentation.py"],
-                   env=env)
+        out = call_with_scorep("cases/instrumentation.py",
+                               ["--nocompiler"],
+                               env=env)
         std_out = out[1]
         std_err = out[2]
 
@@ -231,13 +226,9 @@ class TestScorepBindingsPython(unittest.TestCase):
         env["SCOREP_EXPERIMENT_DIRECTORY"] += "/test_user_instrumentation"
         trace_path = env["SCOREP_EXPERIMENT_DIRECTORY"] + "/traces.otf2"
 
-        out = call([self.python,
-                    "-m",
-                    "scorep",
-                    "--nocompiler",
-                    "--noinstrumenter",
-                    "cases/user_instrumentation.py"],
-                   env=env)
+        out = call_with_scorep("cases/user_instrumentation.py",
+                               ["--nocompiler", "--noinstrumenter"],
+                               env=env)
         std_out = out[1]
         std_err = out[2]
 
@@ -259,13 +250,9 @@ class TestScorepBindingsPython(unittest.TestCase):
         env["SCOREP_EXPERIMENT_DIRECTORY"] += "/test_error_region"
         trace_path = env["SCOREP_EXPERIMENT_DIRECTORY"] + "/traces.otf2"
 
-        out = call([self.python,
-                    "-m",
-                    "scorep",
-                    "--nocompiler",
-                    "--noinstrumenter",
-                    "cases/error_region.py"],
-                   env=env)
+        out = call_with_scorep("cases/error_region.py",
+                               ["--nocompiler", "--noinstrumenter"],
+                               env=env)
         std_out = out[1]
         std_err = out[2]
 
@@ -306,7 +293,7 @@ class TestScorepBindingsPython(unittest.TestCase):
                     "-mca",
                     "btl",
                     "^openib",
-                    self.python,
+                    sys.executable,
                     "-m",
                     "scorep",
                     "--mpp=mpi",
@@ -326,12 +313,9 @@ class TestScorepBindingsPython(unittest.TestCase):
     def test_call_main(self):
         env = self.env
         env["SCOREP_EXPERIMENT_DIRECTORY"] += "/test_call_main"
-        out = call([self.python,
-                    "-m",
-                    "scorep",
-                    "--nocompiler",
-                    "cases/call_main.py"],
-                   env=env)
+        out = call_with_scorep("cases/call_main.py",
+                               ["--nocompiler"],
+                               env=env)
         std_out = out[1]
         std_err = out[2]
 
@@ -344,12 +328,9 @@ class TestScorepBindingsPython(unittest.TestCase):
         env = self.env
         env["SCOREP_EXPERIMENT_DIRECTORY"] += "/test_dummy"
 
-        out = call([self.python,
-                    "-m",
-                    "scorep",
-                    "--instrumenter-type=dummy",
-                    "cases/instrumentation.py"],
-                   env=env)
+        out = call_with_scorep("cases/instrumentation.py",
+                               ["--instrumenter-type=dummy"],
+                               env=env)
         std_out = out[1]
         std_err = out[2]
 
@@ -366,13 +347,9 @@ class TestScorepBindingsPython(unittest.TestCase):
         env["SCOREP_EXPERIMENT_DIRECTORY"] += "/test_numpy_dot"
         trace_path = env["SCOREP_EXPERIMENT_DIRECTORY"] + "/traces.otf2"
 
-        out = call([self.python,
-                    "-m",
-                    "scorep",
-                    "--nocompiler",
-                    "--noinstrumenter",
-                    "cases/numpy_dot.py"],
-                   env=env)
+        out = call_with_scorep("cases/numpy_dot.py",
+                               ["--nocompiler", "--noinstrumenter"],
+                               env=env)
         std_out = out[1]
         std_err = out[2]
 


### PR DESCRIPTION
In preparation for #80 I changed the CI scripts to use pytest already and reduced the testcase instance and class variables as far as possible. As part of that `call_with_scorep` is introduced to reduce some code duplication especially related to `sys.executable`/`self.python`

Next step would be to remove the `TestScorepBindingsPython` and use pytest fixtures instead so the parametrization feature can be used, but that will be a large diff, so for easier reviews I created this PR.