### PR TITLE
Implement CInstrumenter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,22 +10,22 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 find_package(Scorep REQUIRED)
 find_package(Python REQUIRED COMPONENTS Interpreter Development)
 
-Python_add_library(scorep_bindings
+Python_add_library(_bindings
   src/methods.cpp src/scorep_bindings.cpp src/scorepy/events.cpp
 )
 if(Python_VERSION_MAJOR GREATER_EQUAL 3)
-  target_sources(scorep_bindings PRIVATE src/classes.cpp src/scorepy/cInstrumenter.cpp src/scorepy/pythonHelpers.cpp)
+  target_sources(_bindings PRIVATE src/classes.cpp src/scorepy/cInstrumenter.cpp src/scorepy/pythonHelpers.cpp)
 endif()
-target_link_libraries(scorep_bindings PRIVATE Scorep::Plugin)
-target_compile_features(scorep_bindings PRIVATE cxx_std_11)
-target_compile_definitions(scorep_bindings PRIVATE PY_SSIZE_T_CLEAN)
-target_include_directories(scorep_bindings PRIVATE src)
+target_link_libraries(_bindings PRIVATE Scorep::Plugin)
+target_compile_features(_bindings PRIVATE cxx_std_11)
+target_compile_definitions(_bindings PRIVATE PY_SSIZE_T_CLEAN)
+target_include_directories(_bindings PRIVATE src)
 
-set_target_properties(scorep_bindings PROPERTIES
+set_target_properties(_bindings PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/site-packages/scorep
 )
 add_custom_target(ScorepModule ALL
-  ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_LIST_DIR}/scorep $<TARGET_FILE_DIR:scorep_bindings>
+  ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_LIST_DIR}/scorep $<TARGET_FILE_DIR:_bindings>
   COMMENT "Copying module files to build tree"
 )
 
@@ -43,4 +43,4 @@ set_tests_properties(ScorepPythonTests PROPERTIES ENVIRONMENT "PYTHONPATH=${pyth
 set(INSTALL_DIR "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
 
 install(DIRECTORY scorep DESTINATION ${INSTALL_DIR})
-install(TARGETS scorep_bindings DESTINATION ${INSTALL_DIR}/scorep)
+install(TARGETS _bindings DESTINATION ${INSTALL_DIR}/scorep)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ find_package(Python REQUIRED COMPONENTS Interpreter Development)
 Python_add_library(scorep_bindings
   src/methods.cpp src/scorep_bindings.cpp src/scorepy/events.cpp
 )
+if(Python_VERSION_MAJOR GREATER_EQUAL 3)
+  target_sources(scorep_bindings PRIVATE src/classes.cpp src/scorepy/cInstrumenter.cpp src/scorepy/pythonHelpers.cpp)
+endif()
 target_link_libraries(scorep_bindings PRIVATE Scorep::Plugin)
 target_compile_features(scorep_bindings PRIVATE cxx_std_11)
 target_compile_definitions(scorep_bindings PRIVATE PY_SSIZE_T_CLEAN)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ To trace the full script, you need to run
 python -m scorep <script.py>
 ```
 
-The usual Score-P environment Variables will be respected. Please have a look at:
+The usual Score-P environment Variables will be respected.
+Please have a look at:
 
 [www.vi-hps.org](http://www.vi-hps.org/projects/score-p/)
 
@@ -62,20 +63,24 @@ python -m scorep --mpp=mpi --thread=pthread <script.py>
 
 ## Instrumenter
 The instrumenter ist the key part of the bindings.
-He registers with the Python tracing interface, and cares about the fowarding of events to Score-P.
-There are currently three different instrumenter types available as described in the following section [Instrumenter Types](#instrumenter-types) .
+It registers with the Python tracing interface, and cares about the fowarding of events to Score-P.
+There are currently five different instrumenter types available as described in the following section [Instrumenter Types](#instrumenter-types) .
 A user interface, to dynamically enable and disable the automatic instrumentation, using the python hooks, is also available and described under [Instrumenter User Interface](#instrumenter-user-interface)
 
 ### Instrumenter Types
-With version 2.0 of the python bindings, the term "instrumenter" is introduced. The instrumenter describes the class that maps the Python `trace` or `profile` events to Score-P. Please be aware, that `trace` and `profile` does not refer to the traditional Score-P terms of tracing and profiling, but to the Python functions [sys.settrace](https://docs.python.org/3/library/sys.html#sys.settrace) and [sys.setprofile](https://docs.python.org/3/library/sys.html#sys.setprofile).
+With version 2.0 of the python bindings, the term "instrumenter" is introduced.
+The instrumenter describes the class that maps the Python `trace` or `profile` events to Score-P.
+Please be aware, that `trace` and `profile` does not refer to the traditional Score-P terms of tracing and profiling, but to the Python functions [sys.settrace](https://docs.python.org/3/library/sys.html#sys.settrace) and [sys.setprofile](https://docs.python.org/3/library/sys.html#sys.setprofile).
 
 The instrumenter that shall be used for tracing can be specified using `--instrumenter-type=<type>`.
-Currently there are the following tacers available:
+Currently there are the following instrumenters available:
  * `profile` (default) implements `call` and `return`  
  * `trace` implements `call` and `return`
+ * `cProfile` / `cTrace` are the same as the above but implemented in C++
  * `dummy` does nothing, can be used without `-m scorep` (as done by user instrumentation)
 
 The `profile` instrumenter should have a smaller overhead than `trace`.
+Using the instrumenters implemented in C++ additionally reduces the overhead but those are only available in Python 3.
 
 It is possible to disable the instrumenter passing  `--noinstrumenter`.
 However, the [Instrumenter User Interface](#instrumenter-user-interface) may override this flag.
@@ -196,22 +201,23 @@ scorep.user.parameter_uint(name, val)
 scorep.user.parameter_string(name, string)
 ```
 
-where `name` defines the name of the parameter or region, while `val` or `string` represents the value that is passed to Score-P. 
+where `name` defines the name of the parameter or region, while `val` or `string` represents the value that is passed to Score-P.
 
-Disabeling the recording with Score-P is still also possilbe:
+Disabling the recording with Score-P is still also possible:
 
 ```
 scorep.user.enable_recording()
 scorep.user.disable_recording()
 ```
 
-However, please be aware that the runtime impact of disabeling Score-P is rather small, as the instrumenter is still active. For details about the instrumenter, please see [Instrumenter](#Instrumenter).  
+However, please be aware that the runtime impact of disabling Score-P is rather small, as the instrumenter is still active.
+For details about the instrumenter, please see [Instrumenter](#Instrumenter).
 
 ## Overview about Flags
 
 The following flags are special to the python bindings:
 
- * `--noinstrumenter` disables the instrumentation of python code. Usefull for user instrumentation and to trace only specific code regions using `scorep.instrumenter.enable`.
+ * `--noinstrumenter` disables the instrumentation of python code. Useful for user instrumentation and to trace only specific code regions using `scorep.instrumenter.enable`.
  * `--instrumenter-type=<type>` choose an instrumenter. See  [Instrumenter](#Instrumenter).
  * `--keep-files` temporary files are kept.
 
@@ -235,7 +241,8 @@ To disable compiler instrumentation, please specify:
 python -m scorep --nocompiler <script.py>
 ```
 
-For other thread schemes just specify `--thread=<something>`. E.g. :
+For other thread schemes just specify `--thread=<something>`.
+E.g. :
 
 ```
 python -m scorep --thread=omp <script.py>
@@ -246,7 +253,7 @@ Please be aware the `--user` is always passed to Score-P, as this is needed for 
 # Compatibility
 ## Working
 * python3 
-* python2.7
+* python2.7, but not all features are supported
 * mpi using mpi4py
 * threaded applications
 

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -3,6 +3,7 @@ Created on 04.10.2019
 
 @author: gocht
 '''
+import sys
 import benchmark_helper
 import pickle
 
@@ -16,6 +17,9 @@ reps_x["bm_simplefunc.py"] = ["100000", "200000", "300000", "400000", "500000"]
 
 for test in tests:
     results[test] = {"profile": {}, "trace": {}, "dummy": {}, "None": {}}
+    if sys.version_info.major >= 3:
+        results.update({"cProfile": {}, "cTrace": {}})
+
     for instrumenter in results[test]:
         if instrumenter == "None":
             enable_scorep = False

--- a/scorep/_instrumenters/scorep_cProfile.py
+++ b/scorep/_instrumenters/scorep_cProfile.py
@@ -4,7 +4,7 @@ import scorep._bindings
 
 class ScorepCProfile(scorep._bindings.CInstrumenter, ScorepInstrumenter):
     def __init__(self, enable_instrumenter):
-        scorep._bindings.CInstrumenter.__init__(self, tracing_or_profiling=False)
+        scorep._bindings.CInstrumenter.__init__(self, interface='Profile')
         ScorepInstrumenter.__init__(self, enable_instrumenter)
 
     def _enable_instrumenter(self):

--- a/scorep/_instrumenters/scorep_cProfile.py
+++ b/scorep/_instrumenters/scorep_cProfile.py
@@ -6,3 +6,13 @@ class ScorepCProfile(scorep_bindings.CInstrumenter, ScorepInstrumenter):
     def __init__(self, enable_instrumenter):
         scorep_bindings.CInstrumenter.__init__(self, tracingOrProfiling=False)
         ScorepInstrumenter.__init__(self, enable_instrumenter)
+
+    def _enable_instrumenter(self):
+        if self._threading:
+            self._threading.setprofile(self)
+        super()._enable_instrumenter()
+
+    def _disable_instrumenter(self):
+        super()._disable_instrumenter()
+        if self._threading:
+            self._threading.setprofile(None)

--- a/scorep/_instrumenters/scorep_cProfile.py
+++ b/scorep/_instrumenters/scorep_cProfile.py
@@ -1,0 +1,8 @@
+from scorep._instrumenters.scorep_instrumenter import ScorepInstrumenter
+from scorep import scorep_bindings
+
+
+class ScorepCProfile(scorep_bindings.CInstrumenter, ScorepInstrumenter):
+    def __init__(self, enable_instrumenter):
+        scorep_bindings.CInstrumenter.__init__(self, tracingOrProfiling=False)
+        ScorepInstrumenter.__init__(self, enable_instrumenter)

--- a/scorep/_instrumenters/scorep_cProfile.py
+++ b/scorep/_instrumenters/scorep_cProfile.py
@@ -1,5 +1,5 @@
 from scorep._instrumenters.scorep_instrumenter import ScorepInstrumenter
-from scorep import scorep_bindings
+from scorep import _bindings as scorep_bindings
 
 
 class ScorepCProfile(scorep_bindings.CInstrumenter, ScorepInstrumenter):

--- a/scorep/_instrumenters/scorep_cProfile.py
+++ b/scorep/_instrumenters/scorep_cProfile.py
@@ -1,10 +1,10 @@
 from scorep._instrumenters.scorep_instrumenter import ScorepInstrumenter
-from scorep import _bindings as scorep_bindings
+import scorep._bindings
 
 
-class ScorepCProfile(scorep_bindings.CInstrumenter, ScorepInstrumenter):
+class ScorepCProfile(scorep._bindings.CInstrumenter, ScorepInstrumenter):
     def __init__(self, enable_instrumenter):
-        scorep_bindings.CInstrumenter.__init__(self, tracingOrProfiling=False)
+        scorep._bindings.CInstrumenter.__init__(self, tracingOrProfiling=False)
         ScorepInstrumenter.__init__(self, enable_instrumenter)
 
     def _enable_instrumenter(self):

--- a/scorep/_instrumenters/scorep_cProfile.py
+++ b/scorep/_instrumenters/scorep_cProfile.py
@@ -4,7 +4,7 @@ import scorep._bindings
 
 class ScorepCProfile(scorep._bindings.CInstrumenter, ScorepInstrumenter):
     def __init__(self, enable_instrumenter):
-        scorep._bindings.CInstrumenter.__init__(self, tracingOrProfiling=False)
+        scorep._bindings.CInstrumenter.__init__(self, tracing_or_profiling=False)
         ScorepInstrumenter.__init__(self, enable_instrumenter)
 
     def _enable_instrumenter(self):

--- a/scorep/_instrumenters/scorep_cProfile.py
+++ b/scorep/_instrumenters/scorep_cProfile.py
@@ -6,13 +6,3 @@ class ScorepCProfile(scorep._bindings.CInstrumenter, ScorepInstrumenter):
     def __init__(self, enable_instrumenter):
         scorep._bindings.CInstrumenter.__init__(self, interface='Profile')
         ScorepInstrumenter.__init__(self, enable_instrumenter)
-
-    def _enable_instrumenter(self):
-        if self._threading:
-            self._threading.setprofile(self)
-        super()._enable_instrumenter()
-
-    def _disable_instrumenter(self):
-        super()._disable_instrumenter()
-        if self._threading:
-            self._threading.setprofile(None)

--- a/scorep/_instrumenters/scorep_cTrace.py
+++ b/scorep/_instrumenters/scorep_cTrace.py
@@ -6,3 +6,13 @@ class ScorepCTrace(scorep_bindings.CInstrumenter, ScorepInstrumenter):
     def __init__(self, enable_instrumenter):
         scorep_bindings.CInstrumenter.__init__(self, tracingOrProfiling=True)
         ScorepInstrumenter.__init__(self, enable_instrumenter)
+
+    def _enable_instrumenter(self):
+        if self._threading:
+            self._threading.settrace(self)
+        super()._enable_instrumenter()
+
+    def _disable_instrumenter(self):
+        super()._disable_instrumenter()
+        if self._threading:
+            self._threading.settrace(None)

--- a/scorep/_instrumenters/scorep_cTrace.py
+++ b/scorep/_instrumenters/scorep_cTrace.py
@@ -4,7 +4,7 @@ import scorep._bindings
 
 class ScorepCTrace(scorep._bindings.CInstrumenter, ScorepInstrumenter):
     def __init__(self, enable_instrumenter):
-        scorep._bindings.CInstrumenter.__init__(self, tracingOrProfiling=True)
+        scorep._bindings.CInstrumenter.__init__(self, tracing_or_profiling=True)
         ScorepInstrumenter.__init__(self, enable_instrumenter)
 
     def _enable_instrumenter(self):

--- a/scorep/_instrumenters/scorep_cTrace.py
+++ b/scorep/_instrumenters/scorep_cTrace.py
@@ -1,5 +1,5 @@
 from scorep._instrumenters.scorep_instrumenter import ScorepInstrumenter
-from scorep import scorep_bindings
+from scorep import _bindings as scorep_bindings
 
 
 class ScorepCTrace(scorep_bindings.CInstrumenter, ScorepInstrumenter):

--- a/scorep/_instrumenters/scorep_cTrace.py
+++ b/scorep/_instrumenters/scorep_cTrace.py
@@ -1,0 +1,8 @@
+from scorep._instrumenters.scorep_instrumenter import ScorepInstrumenter
+from scorep import scorep_bindings
+
+
+class ScorepCTrace(scorep_bindings.CInstrumenter, ScorepInstrumenter):
+    def __init__(self, enable_instrumenter):
+        scorep_bindings.CInstrumenter.__init__(self, tracingOrProfiling=True)
+        ScorepInstrumenter.__init__(self, enable_instrumenter)

--- a/scorep/_instrumenters/scorep_cTrace.py
+++ b/scorep/_instrumenters/scorep_cTrace.py
@@ -6,13 +6,3 @@ class ScorepCTrace(scorep._bindings.CInstrumenter, ScorepInstrumenter):
     def __init__(self, enable_instrumenter):
         scorep._bindings.CInstrumenter.__init__(self, interface='Trace')
         ScorepInstrumenter.__init__(self, enable_instrumenter)
-
-    def _enable_instrumenter(self):
-        if self._threading:
-            self._threading.settrace(self)
-        super()._enable_instrumenter()
-
-    def _disable_instrumenter(self):
-        super()._disable_instrumenter()
-        if self._threading:
-            self._threading.settrace(None)

--- a/scorep/_instrumenters/scorep_cTrace.py
+++ b/scorep/_instrumenters/scorep_cTrace.py
@@ -4,7 +4,7 @@ import scorep._bindings
 
 class ScorepCTrace(scorep._bindings.CInstrumenter, ScorepInstrumenter):
     def __init__(self, enable_instrumenter):
-        scorep._bindings.CInstrumenter.__init__(self, tracing_or_profiling=True)
+        scorep._bindings.CInstrumenter.__init__(self, interface='Trace')
         ScorepInstrumenter.__init__(self, enable_instrumenter)
 
     def _enable_instrumenter(self):

--- a/scorep/_instrumenters/scorep_cTrace.py
+++ b/scorep/_instrumenters/scorep_cTrace.py
@@ -1,10 +1,10 @@
 from scorep._instrumenters.scorep_instrumenter import ScorepInstrumenter
-from scorep import _bindings as scorep_bindings
+import scorep._bindings
 
 
-class ScorepCTrace(scorep_bindings.CInstrumenter, ScorepInstrumenter):
+class ScorepCTrace(scorep._bindings.CInstrumenter, ScorepInstrumenter):
     def __init__(self, enable_instrumenter):
-        scorep_bindings.CInstrumenter.__init__(self, tracingOrProfiling=True)
+        scorep._bindings.CInstrumenter.__init__(self, tracingOrProfiling=True)
         ScorepInstrumenter.__init__(self, enable_instrumenter)
 
     def _enable_instrumenter(self):

--- a/scorep/_instrumenters/scorep_instrumenter.py
+++ b/scorep/_instrumenters/scorep_instrumenter.py
@@ -15,12 +15,6 @@ class ScorepInstrumenter(base_instrumenter.BaseInstrumenter):
         """
         self._tracer_registered = False
         self._enabled = enable_instrumenter
-        # TODO: Support other threading libs, e.g. greenlet?
-        try:
-            import threading
-            self._threading = threading
-        except ImportError:
-            self._threading = None
 
     @abc.abstractmethod
     def _enable_instrumenter(self):

--- a/scorep/_instrumenters/scorep_instrumenter.py
+++ b/scorep/_instrumenters/scorep_instrumenter.py
@@ -2,7 +2,7 @@ import abc
 import inspect
 import os
 from scorep._instrumenters import base_instrumenter
-from scorep import scorep_bindings
+from scorep import _bindings as scorep_bindings
 
 
 class ScorepInstrumenter(base_instrumenter.BaseInstrumenter):

--- a/scorep/_instrumenters/scorep_instrumenter.py
+++ b/scorep/_instrumenters/scorep_instrumenter.py
@@ -15,6 +15,12 @@ class ScorepInstrumenter(base_instrumenter.BaseInstrumenter):
         """
         self._tracer_registered = False
         self._enabled = enable_instrumenter
+        # TODO: Support other threading libs, e.g. greenlet?
+        try:
+            import threading
+            self._threading = threading
+        except ImportError:
+            self._threading = None
 
     @abc.abstractmethod
     def _enable_instrumenter(self):

--- a/scorep/_instrumenters/scorep_instrumenter.py
+++ b/scorep/_instrumenters/scorep_instrumenter.py
@@ -2,7 +2,7 @@ import abc
 import inspect
 import os
 from scorep._instrumenters import base_instrumenter
-from scorep import _bindings as scorep_bindings
+import scorep._bindings
 
 
 class ScorepInstrumenter(base_instrumenter.BaseInstrumenter):
@@ -64,12 +64,12 @@ class ScorepInstrumenter(base_instrumenter.BaseInstrumenter):
 
     def region_begin(self, module_name, function_name, file_name, line_number):
         """Record a region begin event"""
-        scorep_bindings.region_begin(
+        scorep._bindings.region_begin(
             module_name, function_name, file_name, line_number)
 
     def region_end(self, module_name, function_name):
         """Record a region end event"""
-        scorep_bindings.region_end(module_name, function_name)
+        scorep._bindings.region_end(module_name, function_name)
 
     def rewind_begin(self, name, file_name=None, line_number=None):
         """
@@ -88,7 +88,7 @@ class ScorepInstrumenter(base_instrumenter.BaseInstrumenter):
         else:
             full_file_name = "None"
 
-        scorep_bindings.rewind_begin(name, full_file_name, line_number)
+        scorep._bindings.rewind_begin(name, full_file_name, line_number)
 
     def rewind_end(self, name, value):
         """
@@ -96,7 +96,7 @@ class ScorepInstrumenter(base_instrumenter.BaseInstrumenter):
         @param name name of the user region
         @param value True or False, whenether the region shall be rewinded or not.
         """
-        scorep_bindings.rewind_end(name, value)
+        scorep._bindings.rewind_end(name, value)
 
     def oa_region_begin(self, name, file_name=None, line_number=None):
         """
@@ -115,28 +115,28 @@ class ScorepInstrumenter(base_instrumenter.BaseInstrumenter):
         else:
             full_file_name = "None"
 
-        scorep_bindings.oa_region_begin(name, full_file_name, line_number)
+        scorep._bindings.oa_region_begin(name, full_file_name, line_number)
 
     def oa_region_end(self, name):
         """End an Online Access region."""
-        scorep_bindings.oa_region_end(name)
+        scorep._bindings.oa_region_end(name)
 
     def user_enable_recording(self):
         """Enable writing of trace events in ScoreP"""
-        scorep_bindings.enable_recording()
+        scorep._bindings.enable_recording()
 
     def user_disable_recording(self):
         """Disable writing of trace events in ScoreP"""
-        scorep_bindings.disable_recording()
+        scorep._bindings.disable_recording()
 
     def user_parameter_int(self, name, val):
         """Record a parameter of type integer"""
-        scorep_bindings.parameter_int(name, val)
+        scorep._bindings.parameter_int(name, val)
 
     def user_parameter_uint(self, name, val):
         """Record a parameter of type unsigned integer"""
-        scorep_bindings.parameter_string(name, val)
+        scorep._bindings.parameter_string(name, val)
 
     def user_parameter_string(self, name, string):
         """Record a parameter of type string"""
-        scorep_bindings.parameter_string(name, string)
+        scorep._bindings.parameter_string(name, string)

--- a/scorep/_instrumenters/scorep_profile.py
+++ b/scorep/_instrumenters/scorep_profile.py
@@ -3,7 +3,7 @@ __all__ = ['ScorepProfile']
 import sys
 from scorep._instrumenters.utils import get_module_name, get_file_name
 from scorep._instrumenters.scorep_instrumenter import ScorepInstrumenter
-from scorep import scorep_bindings
+from scorep import _bindings as scorep_bindings
 
 try:
     import threading

--- a/scorep/_instrumenters/scorep_profile.py
+++ b/scorep/_instrumenters/scorep_profile.py
@@ -3,7 +3,7 @@ __all__ = ['ScorepProfile']
 import sys
 from scorep._instrumenters.utils import get_module_name, get_file_name
 from scorep._instrumenters.scorep_instrumenter import ScorepInstrumenter
-from scorep import _bindings as scorep_bindings
+import scorep._bindings
 
 try:
     import threading
@@ -42,9 +42,9 @@ class ScorepProfile(ScorepInstrumenter):
             if not code.co_name == "_unsetprofile" and not modulename[:6] == "scorep":
                 full_file_name = get_file_name(frame)
                 line_number = code.co_firstlineno
-                scorep_bindings.region_begin(modulename, code.co_name, full_file_name, line_number)
+                scorep._bindings.region_begin(modulename, code.co_name, full_file_name, line_number)
         elif why == 'return':
             code = frame.f_code
             modulename = get_module_name(frame)
             if not code.co_name == "_unsetprofile" and not modulename[:6] == "scorep":
-                scorep_bindings.region_end(modulename, code.co_name)
+                scorep._bindings.region_end(modulename, code.co_name)

--- a/scorep/_instrumenters/scorep_trace.py
+++ b/scorep/_instrumenters/scorep_trace.py
@@ -3,7 +3,7 @@ __all__ = ['ScorepTrace']
 import sys
 from scorep._instrumenters.utils import get_module_name, get_file_name
 from scorep._instrumenters.scorep_instrumenter import ScorepInstrumenter
-from scorep import scorep_bindings
+from scorep import _bindings as scorep_bindings
 
 try:
     import threading

--- a/scorep/_instrumenters/scorep_trace.py
+++ b/scorep/_instrumenters/scorep_trace.py
@@ -3,7 +3,7 @@ __all__ = ['ScorepTrace']
 import sys
 from scorep._instrumenters.utils import get_module_name, get_file_name
 from scorep._instrumenters.scorep_instrumenter import ScorepInstrumenter
-from scorep import _bindings as scorep_bindings
+import scorep._bindings
 
 try:
     import threading
@@ -40,7 +40,7 @@ class ScorepTrace(ScorepInstrumenter):
             if not code.co_name == "_unsettrace" and not modulename[:6] == "scorep":
                 full_file_name = get_file_name(frame)
                 line_number = code.co_firstlineno
-                scorep_bindings.region_begin(modulename, code.co_name, full_file_name, line_number)
+                scorep._bindings.region_begin(modulename, code.co_name, full_file_name, line_number)
                 return self._localtrace
         return None
 
@@ -48,5 +48,5 @@ class ScorepTrace(ScorepInstrumenter):
         if why == 'return':
             code = frame.f_code
             modulename = get_module_name(frame)
-            scorep_bindings.region_end(modulename, code.co_name)
+            scorep._bindings.region_end(modulename, code.co_name)
         return self._localtrace

--- a/scorep/instrumenter.py
+++ b/scorep/instrumenter.py
@@ -24,6 +24,12 @@ def get_instrumenter(enable_instrumenter=False,
         elif instrumenter_type == "dummy":
             from scorep._instrumenters.dummy import ScorepDummy
             global_instrumenter = ScorepDummy(enable_instrumenter)
+        elif instrumenter_type == "cTrace":
+            from scorep._instrumenters.scorep_cTrace import ScorepCTrace
+            global_instrumenter = ScorepCTrace(enable_instrumenter)
+        elif instrumenter_type == "cProfile":
+            from scorep._instrumenters.scorep_cProfile import ScorepCProfile
+            global_instrumenter = ScorepCProfile(enable_instrumenter)
         else:
             raise RuntimeError('instrumenter_type "{}" unkown'.format(instrumenter_type))
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from distutils.core import setup, Extension
 import scorep.helper
 
@@ -24,6 +25,8 @@ cmodules = []
 src_folder = os.path.abspath('src')
 include += [src_folder]
 sources = ['src/methods.cpp', 'src/scorep_bindings.cpp', 'src/scorepy/events.cpp']
+if sys.version_info.major >= 3:
+    sources.extend(['src/classes.cpp', 'src/scorepy/cInstrumenter.cpp', 'src/scorepy/pythonHelpers.cpp'])
 
 cmodules.append(Extension('scorep.scorep_bindings',
                           include_dirs=include,

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ sources = ['src/methods.cpp', 'src/scorep_bindings.cpp', 'src/scorepy/events.cpp
 if sys.version_info.major >= 3:
     sources.extend(['src/classes.cpp', 'src/scorepy/cInstrumenter.cpp', 'src/scorepy/pythonHelpers.cpp'])
 
-cmodules.append(Extension('scorep.scorep_bindings',
+cmodules.append(Extension('scorep._bindings',
                           include_dirs=include,
                           define_macros=[('PY_SSIZE_T_CLEAN', '1')],
                           extra_compile_args=["-std=c++11"],

--- a/src/classes.cpp
+++ b/src/classes.cpp
@@ -55,6 +55,21 @@ extern "C"
         self->disable_instrumenter();
         Py_RETURN_NONE;
     }
+
+    static PyObject* CInstrumenter_call(scorepy::CInstrumenter* self, PyObject* args,
+                                        PyObject* kwds)
+    {
+        static const char* kwlist[] = { "frame", "event", "arg", nullptr };
+
+        PyFrameObject* frame;
+        const char* event;
+        PyObject* arg;
+
+        if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!sO", const_cast<char**>(kwlist),
+                                         &PyFrame_Type, &frame, &event, &arg))
+            return nullptr;
+        return (*self)(*frame, event, arg);
+    }
 }
 
 namespace scorepy
@@ -84,6 +99,7 @@ PyTypeObject& getCInstrumenterType()
     type.tp_new = call_object_new;
     type.tp_init = scorepy::castToPyFunc(CInstrumenter_init);
     type.tp_methods = methods;
+    type.tp_call = scorepy::castToPyFunc(CInstrumenter_call);
     type.tp_getset = getseters;
     type.tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE;
     type.tp_doc = "Class for the C instrumenter interface of Score-P";

--- a/src/classes.cpp
+++ b/src/classes.cpp
@@ -24,6 +24,12 @@ extern "C"
         return PyBaseObject_Type.tp_new(type, empty_tuple, empty_dict);
     }
 
+    static void CInstrumenter_dealloc(scorepy::CInstrumenter* self)
+    {
+        self->deinit();
+        Py_TYPE(self)->tp_free(self->to_PyObject());
+    }
+
     static int CInstrumenter_init(scorepy::CInstrumenter* self, PyObject* args, PyObject* kwds)
     {
         static const char* kwlist[] = { "interface", nullptr };
@@ -110,6 +116,7 @@ PyTypeObject& getCInstrumenterType()
     };
     type.tp_new = call_object_new;
     type.tp_init = scorepy::cast_to_PyFunc(CInstrumenter_init);
+    type.tp_dealloc = scorepy::cast_to_PyFunc(CInstrumenter_dealloc);
     type.tp_methods = methods;
     type.tp_call = scorepy::cast_to_PyFunc(CInstrumenter_call);
     type.tp_getset = getseters;

--- a/src/classes.cpp
+++ b/src/classes.cpp
@@ -63,15 +63,14 @@ namespace scorepy
 PyTypeObject& getCInstrumenterType()
 {
     static PyMethodDef methods[] = {
-        { "_enable_instrumenter", reinterpret_cast<PyCFunction>(CInstrumenter_enable_instrumenter),
+        { "_enable_instrumenter", scorepy::castToPyFunc(CInstrumenter_enable_instrumenter),
           METH_NOARGS, "Enable the instrumenter" },
-        { "_disable_instrumenter",
-          reinterpret_cast<PyCFunction>(CInstrumenter_disable_instrumenter), METH_NOARGS,
-          "Disable the instrumenter" },
+        { "_disable_instrumenter", scorepy::castToPyFunc(CInstrumenter_disable_instrumenter),
+          METH_NOARGS, "Disable the instrumenter" },
         { nullptr } /* Sentinel */
     };
     static PyGetSetDef getseters[] = {
-        { "tracingOrProfiling", reinterpret_cast<getter>(CInstrumenter_get_tracingOrProfiling),
+        { "tracingOrProfiling", scorepy::castToPyFunc(CInstrumenter_get_tracingOrProfiling),
           nullptr, "Return whether the trace (True) or profile (False) instrumentation is used",
           nullptr },
         { nullptr } /* Sentinel */
@@ -83,7 +82,7 @@ PyTypeObject& getCInstrumenterType()
         sizeof(CInstrumenter),                  /* tp_basicsize */
     };
     type.tp_new = call_object_new;
-    type.tp_init = reinterpret_cast<initproc>(CInstrumenter_init);
+    type.tp_init = scorepy::castToPyFunc(CInstrumenter_init);
     type.tp_methods = methods;
     type.tp_getset = getseters;
     type.tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE;

--- a/src/classes.cpp
+++ b/src/classes.cpp
@@ -17,10 +17,14 @@ extern "C"
     {
         scorepy::PyRefObject empty_tuple(PyTuple_New(0), scorepy::adopt_object);
         if (!empty_tuple)
+        {
             return nullptr;
+        }
         scorepy::PyRefObject empty_dict(PyDict_New(), scorepy::adopt_object);
         if (!empty_dict)
+        {
             return nullptr;
+        }
         return PyBaseObject_Type.tp_new(type, empty_tuple, empty_dict);
     }
 
@@ -37,14 +41,20 @@ extern "C"
 
         if (!PyArg_ParseTupleAndKeywords(args, kwds, "s", const_cast<char**>(kwlist),
                                          &interface_cstring))
+        {
             return -1;
+        }
 
         const std::string interface_string = interface_cstring;
         scorepy::InstrumenterInterface interface;
         if (interface_string == "Trace")
+        {
             interface = scorepy::InstrumenterInterface::Trace;
+        }
         else if (interface_string == "Profile")
+        {
             interface = scorepy::InstrumenterInterface::Profile;
+        }
         else
         {
             PyErr_Format(PyExc_TypeError, "Expected 'Trace' or 'Profile', got '%s'",
@@ -86,7 +96,9 @@ extern "C"
 
         if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!sO", const_cast<char**>(kwlist),
                                          &PyFrame_Type, &frame, &event, &arg))
+        {
             return nullptr;
+        }
         return (*self)(*frame, event, arg);
     }
 }

--- a/src/classes.cpp
+++ b/src/classes.cpp
@@ -92,9 +92,9 @@ PyTypeObject& getCInstrumenterType()
     };
     // Sets the first few fields explicitely and remaining ones to zero
     static PyTypeObject type = {
-        PyVarObject_HEAD_INIT(nullptr, 0)       /* header */
-        "scorep.scorep_bindings.CInstrumenter", /* tp_name */
-        sizeof(CInstrumenter),                  /* tp_basicsize */
+        PyVarObject_HEAD_INIT(nullptr, 0) /* header */
+        "scorep._bindings.CInstrumenter", /* tp_name */
+        sizeof(CInstrumenter),            /* tp_basicsize */
     };
     type.tp_new = call_object_new;
     type.tp_init = scorepy::castToPyFunc(CInstrumenter_init);

--- a/src/classes.cpp
+++ b/src/classes.cpp
@@ -1,0 +1,94 @@
+#include "classes.hpp"
+#include "scorepy/cInstrumenter.hpp"
+#include "scorepy/pythonHelpers.hpp"
+#include <Python.h>
+#include <type_traits>
+
+static_assert(std::is_trivial<scorepy::CInstrumenter>::value,
+              "Must be trivial or object creation by Python is UB");
+static_assert(std::is_standard_layout<scorepy::CInstrumenter>::value,
+              "Must be standard layout or object creation by Python is UB");
+
+extern "C"
+{
+
+    /// tp_new implementation that calls object.__new__ with not args to allow ABC classes to work
+    static PyObject* call_object_new(PyTypeObject* type, PyObject*, PyObject*)
+    {
+        scorepy::PyRefObject empty_tuple(PyTuple_New(0), scorepy::adopt_object);
+        if (!empty_tuple)
+            return nullptr;
+        scorepy::PyRefObject empty_dict(PyDict_New(), scorepy::adopt_object);
+        if (!empty_dict)
+            return nullptr;
+        return PyBaseObject_Type.tp_new(type, empty_tuple, empty_dict);
+    }
+
+    static int CInstrumenter_init(scorepy::CInstrumenter* self, PyObject* args, PyObject* kwds)
+    {
+        static const char* kwlist[] = { "tracingOrProfiling", nullptr };
+        int tracingOrProfiling;
+
+        if (!PyArg_ParseTupleAndKeywords(args, kwds, "p", const_cast<char**>(kwlist),
+                                         &tracingOrProfiling))
+            return -1;
+
+        self->init(tracingOrProfiling != 0);
+        return 0;
+    }
+
+    static PyObject* CInstrumenter_get_tracingOrProfiling(scorepy::CInstrumenter* self, void*)
+    {
+        scorepy::PyRefObject result(self->tracingOrProfiling ? Py_True : Py_False,
+                                    scorepy::retain_object);
+        return result;
+    }
+
+    static PyObject* CInstrumenter_enable_instrumenter(scorepy::CInstrumenter* self, PyObject*)
+    {
+        self->enable_instrumenter();
+        Py_RETURN_NONE;
+    }
+
+    static PyObject* CInstrumenter_disable_instrumenter(scorepy::CInstrumenter* self, PyObject*)
+    {
+        self->disable_instrumenter();
+        Py_RETURN_NONE;
+    }
+}
+
+namespace scorepy
+{
+
+PyTypeObject& getCInstrumenterType()
+{
+    static PyMethodDef methods[] = {
+        { "_enable_instrumenter", reinterpret_cast<PyCFunction>(CInstrumenter_enable_instrumenter),
+          METH_NOARGS, "Enable the instrumenter" },
+        { "_disable_instrumenter",
+          reinterpret_cast<PyCFunction>(CInstrumenter_disable_instrumenter), METH_NOARGS,
+          "Disable the instrumenter" },
+        { nullptr } /* Sentinel */
+    };
+    static PyGetSetDef getseters[] = {
+        { "tracingOrProfiling", reinterpret_cast<getter>(CInstrumenter_get_tracingOrProfiling),
+          nullptr, "Return whether the trace (True) or profile (False) instrumentation is used",
+          nullptr },
+        { nullptr } /* Sentinel */
+    };
+    // Sets the first few fields explicitely and remaining ones to zero
+    static PyTypeObject type = {
+        PyVarObject_HEAD_INIT(nullptr, 0)       /* header */
+        "scorep.scorep_bindings.CInstrumenter", /* tp_name */
+        sizeof(CInstrumenter),                  /* tp_basicsize */
+    };
+    type.tp_new = call_object_new;
+    type.tp_init = reinterpret_cast<initproc>(CInstrumenter_init);
+    type.tp_methods = methods;
+    type.tp_getset = getseters;
+    type.tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE;
+    type.tp_doc = "Class for the C instrumenter interface of Score-P";
+    return type;
+}
+
+} // namespace scorepy

--- a/src/classes.cpp
+++ b/src/classes.cpp
@@ -26,20 +26,20 @@ extern "C"
 
     static int CInstrumenter_init(scorepy::CInstrumenter* self, PyObject* args, PyObject* kwds)
     {
-        static const char* kwlist[] = { "tracingOrProfiling", nullptr };
-        int tracingOrProfiling;
+        static const char* kwlist[] = { "tracing_or_profiling", nullptr };
+        int tracing_or_profiling;
 
         if (!PyArg_ParseTupleAndKeywords(args, kwds, "p", const_cast<char**>(kwlist),
-                                         &tracingOrProfiling))
+                                         &tracing_or_profiling))
             return -1;
 
-        self->init(tracingOrProfiling != 0);
+        self->init(tracing_or_profiling != 0);
         return 0;
     }
 
     static PyObject* CInstrumenter_get_tracingOrProfiling(scorepy::CInstrumenter* self, void*)
     {
-        scorepy::PyRefObject result(self->tracingOrProfiling ? Py_True : Py_False,
+        scorepy::PyRefObject result(self->tracing_or_profiling ? Py_True : Py_False,
                                     scorepy::retain_object);
         return result;
     }
@@ -78,14 +78,14 @@ namespace scorepy
 PyTypeObject& getCInstrumenterType()
 {
     static PyMethodDef methods[] = {
-        { "_enable_instrumenter", scorepy::castToPyFunc(CInstrumenter_enable_instrumenter),
+        { "_enable_instrumenter", scorepy::cast_to_PyFunc(CInstrumenter_enable_instrumenter),
           METH_NOARGS, "Enable the instrumenter" },
-        { "_disable_instrumenter", scorepy::castToPyFunc(CInstrumenter_disable_instrumenter),
+        { "_disable_instrumenter", scorepy::cast_to_PyFunc(CInstrumenter_disable_instrumenter),
           METH_NOARGS, "Disable the instrumenter" },
         { nullptr } /* Sentinel */
     };
     static PyGetSetDef getseters[] = {
-        { "tracingOrProfiling", scorepy::castToPyFunc(CInstrumenter_get_tracingOrProfiling),
+        { "tracing_or_profiling", scorepy::cast_to_PyFunc(CInstrumenter_get_tracingOrProfiling),
           nullptr, "Return whether the trace (True) or profile (False) instrumentation is used",
           nullptr },
         { nullptr } /* Sentinel */
@@ -97,9 +97,9 @@ PyTypeObject& getCInstrumenterType()
         sizeof(CInstrumenter),            /* tp_basicsize */
     };
     type.tp_new = call_object_new;
-    type.tp_init = scorepy::castToPyFunc(CInstrumenter_init);
+    type.tp_init = scorepy::cast_to_PyFunc(CInstrumenter_init);
     type.tp_methods = methods;
-    type.tp_call = scorepy::castToPyFunc(CInstrumenter_call);
+    type.tp_call = scorepy::cast_to_PyFunc(CInstrumenter_call);
     type.tp_getset = getseters;
     type.tp_flags = Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE;
     type.tp_doc = "Class for the C instrumenter interface of Score-P";

--- a/src/classes.hpp
+++ b/src/classes.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <Python.h>
+
+namespace scorepy
+{
+/// Return the type info to define for the python module
+PyTypeObject& getCInstrumenterType();
+} // namespace scorepy

--- a/src/methods.cpp
+++ b/src/methods.cpp
@@ -35,10 +35,7 @@ extern "C"
         if (!PyArg_ParseTuple(args, "sssK", &module, &region_name, &file_name, &line_number))
             return NULL;
 
-        static std::string region = "";
-        region = module;
-        region += ":";
-        region += region_name;
+        const std::string& region = scorepy::make_region_name(module, region_name);
         scorepy::region_begin(region, module, file_name, line_number);
 
         Py_RETURN_NONE;
@@ -55,10 +52,7 @@ extern "C"
         if (!PyArg_ParseTuple(args, "ss", &module, &region_name))
             return NULL;
 
-        static std::string region = "";
-        region = module;
-        region += ":";
-        region += region_name;
+        const std::string& region = scorepy::make_region_name(module, region_name);
         scorepy::region_end(region);
 
         Py_RETURN_NONE;

--- a/src/scorep.hpp
+++ b/src/scorep.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <Python.h>
+
+namespace scorepy
+{
+/// Return the methods to define for the python module
+PyMethodDef* getMethodTable();
+} // namespace scorepy

--- a/src/scorep_bindings.cpp
+++ b/src/scorep_bindings.cpp
@@ -3,19 +3,18 @@
 #include <Python.h>
 
 #if PY_VERSION_HEX < 0x03000000
-PyMODINIT_FUNC initscorep_bindings(void)
+PyMODINIT_FUNC init_bindings(void)
 {
-    (void)Py_InitModule("scorep_bindings", scorepy::getMethodTable());
+    (void)Py_InitModule("_bindings", scorepy::getMethodTable());
 }
 #else  /*python 3*/
-static struct PyModuleDef scorepmodule = { PyModuleDef_HEAD_INIT,
-                                           "scorep_bindings", /* name of module */
+static struct PyModuleDef scorepmodule = { PyModuleDef_HEAD_INIT, "_bindings", /* name of module */
                                            NULL, /* module documentation, may be NULL */
                                            -1,   /* size of per-interpreter state of the module,
                                                     or -1 if the module keeps state in global
                                                     variables. */
                                            scorepy::getMethodTable() };
-PyMODINIT_FUNC PyInit_scorep_bindings(void)
+PyMODINIT_FUNC PyInit__bindings(void)
 {
     auto* ctracerType = &scorepy::getCInstrumenterType();
     if (PyType_Ready(ctracerType) < 0)

--- a/src/scorep_bindings.cpp
+++ b/src/scorep_bindings.cpp
@@ -22,7 +22,9 @@ PyMODINIT_FUNC PyInit__bindings(void)
 
     auto* m = PyModule_Create(&scorepmodule);
     if (!m)
+    {
         return nullptr;
+    }
 
     Py_INCREF(ctracerType);
     if (PyModule_AddObject(m, "CInstrumenter", (PyObject*)ctracerType) < 0)

--- a/src/scorep_bindings.cpp
+++ b/src/scorep_bindings.cpp
@@ -1,3 +1,4 @@
+#include "classes.hpp"
 #include "methods.hpp"
 #include <Python.h>
 
@@ -16,6 +17,22 @@ static struct PyModuleDef scorepmodule = { PyModuleDef_HEAD_INIT,
                                            scorepy::getMethodTable() };
 PyMODINIT_FUNC PyInit_scorep_bindings(void)
 {
-    return PyModule_Create(&scorepmodule);
+    auto* ctracerType = &scorepy::getCInstrumenterType();
+    if (PyType_Ready(ctracerType) < 0)
+        return nullptr;
+
+    auto* m = PyModule_Create(&scorepmodule);
+    if (!m)
+        return nullptr;
+
+    Py_INCREF(ctracerType);
+    if (PyModule_AddObject(m, "CInstrumenter", (PyObject*)ctracerType) < 0)
+    {
+        Py_DECREF(ctracerType);
+        Py_DECREF(m);
+        return nullptr;
+    }
+
+    return m;
 }
 #endif /*python 3*/

--- a/src/scorepy/cInstrumenter.cpp
+++ b/src/scorepy/cInstrumenter.cpp
@@ -1,0 +1,84 @@
+#include "cInstrumenter.hpp"
+#include "events.hpp"
+#include "pythonHelpers.hpp"
+#include <string>
+
+namespace scorepy
+{
+static const std::string& make_region_name(const char* moduleName, const char* name)
+{
+    static std::string region;
+    region = moduleName;
+    region += ":";
+    region += name;
+    return region;
+}
+
+void CInstrumenter::enable_instrumenter()
+{
+    // TODO: Known issue:  `sys.getprofile()` returns the user object (2nd arg)
+    // So `sys.setprofile(sys.getprofile())` will not round-trip as it will try to call the
+    // 2nd arg. If it is nullptr (here) it means it will be disabled completely
+    // See https://nedbatchelder.com/text/trace-function.html for details
+    const auto callback = [](PyObject* obj, PyFrameObject* frame, int what, PyObject* arg) -> int {
+        return fromPyObject(obj)->onEvent(*frame, what, arg) ? 0 : -1;
+    };
+    if (tracingOrProfiling)
+    {
+        PyEval_SetTrace(callback, toPyObject());
+    }
+    else
+    {
+        PyEval_SetProfile(callback, toPyObject());
+    }
+}
+
+void CInstrumenter::disable_instrumenter()
+{
+    if (tracingOrProfiling)
+        PyEval_SetTrace(nullptr, nullptr);
+    else
+        PyEval_SetProfile(nullptr, nullptr);
+}
+
+bool CInstrumenter::onEvent(PyFrameObject& frame, int what, PyObject*)
+{
+    switch (what)
+    {
+    case PyTrace_CALL:
+    {
+        const PyCodeObject& code = *frame.f_code;
+        const char* name = PyUnicode_AsUTF8(code.co_name);
+        const char* moduleName = get_module_name(frame);
+        assert(name);
+        assert(moduleName);
+        // TODO: Use string_view/CString comparison?
+        if (std::string(name) != "_unsetprofile" && std::string(moduleName, 0, 6) != "scorep")
+        {
+            const int lineNumber = code.co_firstlineno;
+            const auto& regionName = make_region_name(moduleName, name);
+            const auto fileName = get_file_name(frame);
+            region_begin(regionName, moduleName, fileName, lineNumber);
+        }
+        break;
+    }
+    case PyTrace_RETURN:
+    {
+        const PyCodeObject& code = *frame.f_code;
+        const char* name = PyUnicode_AsUTF8(code.co_name);
+        const char* moduleName = get_module_name(frame);
+        assert(name);
+        assert(moduleName);
+        // TODO: Use string_view/CString comparison?
+        if (std::string(name) != "_unsetprofile" && std::string(moduleName, 0, 6) != "scorep")
+        {
+            const auto& regionName = make_region_name(moduleName, name);
+            region_end(regionName);
+        }
+        break;
+    }
+    }
+    return true;
+}
+
+} // namespace scorepy

--- a/src/scorepy/cInstrumenter.cpp
+++ b/src/scorepy/cInstrumenter.cpp
@@ -36,17 +36,25 @@ void CInstrumenter::enable_instrumenter()
                            adopt_object);
     }
     if (interface == InstrumenterInterface::Trace)
+    {
         PyEval_SetTrace(callback, to_PyObject());
+    }
     else
+    {
         PyEval_SetProfile(callback, to_PyObject());
+    }
 }
 
 void CInstrumenter::disable_instrumenter()
 {
     if (interface == InstrumenterInterface::Trace)
+    {
         PyEval_SetTrace(nullptr, nullptr);
+    }
     else
+    {
         PyEval_SetProfile(nullptr, nullptr);
+    }
     if (threading_set_instrumenter)
     {
         PyRefObject result(PyObject_CallFunction(threading_set_instrumenter, "O", Py_None),
@@ -65,9 +73,13 @@ int index_of(TCollection&& col, const TElement& element)
 {
     const auto it = std::find(col.cbegin(), col.cend(), element);
     if (it == col.end())
+    {
         return -1;
+    }
     else
+    {
         return std::distance(col.begin(), it);
+    }
 }
 
 // Required because:  `sys.getprofile()` returns the user object (2nd arg to PyEval_SetTrace)
@@ -81,14 +93,18 @@ PyObject* CInstrumenter::operator()(PyFrameObject& frame, const char* what_strin
     // But we might be inside a `sys.settrace` call where the user wanted to set another function
     // which would then be overwritten here. Hence use the CALL event which avoids the problem
     if (what == PyTrace_CALL)
+    {
         enable_instrumenter();
+    }
     if (on_event(frame, what, arg))
     {
         Py_INCREF(to_PyObject());
         return to_PyObject();
     }
     else
+    {
         return nullptr;
+    }
 }
 
 bool CInstrumenter::on_event(PyFrameObject& frame, int what, PyObject*)

--- a/src/scorepy/cInstrumenter.cpp
+++ b/src/scorepy/cInstrumenter.cpp
@@ -19,21 +19,21 @@ static const std::string& make_region_name(const char* moduleName, const char* n
 void CInstrumenter::enable_instrumenter()
 {
     const auto callback = [](PyObject* obj, PyFrameObject* frame, int what, PyObject* arg) -> int {
-        return fromPyObject(obj)->onEvent(*frame, what, arg) ? 0 : -1;
+        return from_PyObject(obj)->on_event(*frame, what, arg) ? 0 : -1;
     };
-    if (tracingOrProfiling)
+    if (tracing_or_profiling)
     {
-        PyEval_SetTrace(callback, toPyObject());
+        PyEval_SetTrace(callback, to_PyObject());
     }
     else
     {
-        PyEval_SetProfile(callback, toPyObject());
+        PyEval_SetProfile(callback, to_PyObject());
     }
 }
 
 void CInstrumenter::disable_instrumenter()
 {
-    if (tracingOrProfiling)
+    if (tracing_or_profiling)
         PyEval_SetTrace(nullptr, nullptr);
     else
         PyEval_SetProfile(nullptr, nullptr);
@@ -41,33 +41,34 @@ void CInstrumenter::disable_instrumenter()
 
 /// Mapping of PyTrace_* to it's string representations
 /// List taken from CPythons sysmodule.c
-static const std::array<std::string, 8> whatStrings = { "call",     "exception", "line",
-                                                        "return",   "c_call",    "c_exception",
-                                                        "c_return", "opcode" };
+static const std::array<std::string, 8> WHAT_STRINGS = { "call",     "exception", "line",
+                                                         "return",   "c_call",    "c_exception",
+                                                         "c_return", "opcode" };
 
 // Required because:  `sys.getprofile()` returns the user object (2nd arg to PyEval_SetTrace)
 // So `sys.setprofile(sys.getprofile())` will not round-trip as it will try to call the
 // 2nd arg through pythons dispatch function. Hence make the object callable.
 // See https://nedbatchelder.com/text/trace-function.html for details
-PyObject* CInstrumenter::operator()(PyFrameObject& frame, const char* what, PyObject* arg)
+PyObject* CInstrumenter::operator()(PyFrameObject& frame, const char* what_string, PyObject* arg)
 {
-    const auto itWhat = std::find(whatStrings.begin(), whatStrings.end(), what);
-    const int iWhat = itWhat == whatStrings.end() ? -1 : std::distance(whatStrings.begin(), itWhat);
+    const auto it_what = std::find(WHAT_STRINGS.begin(), WHAT_STRINGS.end(), what_string);
+    const int what =
+        it_what == WHAT_STRINGS.end() ? -1 : std::distance(WHAT_STRINGS.begin(), it_what);
     // To speed up further event processing install this class directly as the handler
     // But we might be inside a `sys.settrace` call where the user wanted to set another function
     // which would then be overwritten here. Hence use the CALL event which avoids the problem
-    if (iWhat == PyTrace_CALL)
+    if (what == PyTrace_CALL)
         enable_instrumenter();
-    if (onEvent(frame, iWhat, arg))
+    if (on_event(frame, what, arg))
     {
-        Py_INCREF(toPyObject());
-        return toPyObject();
+        Py_INCREF(to_PyObject());
+        return to_PyObject();
     }
     else
         return nullptr;
 }
 
-bool CInstrumenter::onEvent(PyFrameObject& frame, int what, PyObject*)
+bool CInstrumenter::on_event(PyFrameObject& frame, int what, PyObject*)
 {
     switch (what)
     {
@@ -75,16 +76,16 @@ bool CInstrumenter::onEvent(PyFrameObject& frame, int what, PyObject*)
     {
         const PyCodeObject& code = *frame.f_code;
         const char* name = PyUnicode_AsUTF8(code.co_name);
-        const char* moduleName = get_module_name(frame);
+        const char* module_name = get_module_name(frame);
         assert(name);
-        assert(moduleName);
+        assert(module_name);
         // TODO: Use string_view/CString comparison?
-        if (std::string(name) != "_unsetprofile" && std::string(moduleName, 0, 6) != "scorep")
+        if (std::string(name) != "_unsetprofile" && std::string(module_name, 0, 6) != "scorep")
         {
-            const int lineNumber = code.co_firstlineno;
-            const auto& regionName = make_region_name(moduleName, name);
-            const auto fileName = get_file_name(frame);
-            region_begin(regionName, moduleName, fileName, lineNumber);
+            const int line_number = code.co_firstlineno;
+            const auto& region_name = make_region_name(module_name, name);
+            const auto file_name = get_file_name(frame);
+            region_begin(region_name, module_name, file_name, line_number);
         }
         break;
     }
@@ -92,14 +93,14 @@ bool CInstrumenter::onEvent(PyFrameObject& frame, int what, PyObject*)
     {
         const PyCodeObject& code = *frame.f_code;
         const char* name = PyUnicode_AsUTF8(code.co_name);
-        const char* moduleName = get_module_name(frame);
+        const char* module_name = get_module_name(frame);
         assert(name);
-        assert(moduleName);
+        assert(module_name);
         // TODO: Use string_view/CString comparison?
-        if (std::string(name) != "_unsetprofile" && std::string(moduleName, 0, 6) != "scorep")
+        if (std::string(name) != "_unsetprofile" && std::string(module_name, 0, 6) != "scorep")
         {
-            const auto& regionName = make_region_name(moduleName, name);
-            region_end(regionName);
+            const auto& region_name = make_region_name(module_name, name);
+            region_end(region_name);
         }
         break;
     }

--- a/src/scorepy/cInstrumenter.cpp
+++ b/src/scorepy/cInstrumenter.cpp
@@ -21,19 +21,15 @@ void CInstrumenter::enable_instrumenter()
     const auto callback = [](PyObject* obj, PyFrameObject* frame, int what, PyObject* arg) -> int {
         return from_PyObject(obj)->on_event(*frame, what, arg) ? 0 : -1;
     };
-    if (tracing_or_profiling)
-    {
+    if (interface == InstrumenterInterface::Trace)
         PyEval_SetTrace(callback, to_PyObject());
-    }
     else
-    {
         PyEval_SetProfile(callback, to_PyObject());
-    }
 }
 
 void CInstrumenter::disable_instrumenter()
 {
-    if (tracing_or_profiling)
+    if (interface == InstrumenterInterface::Trace)
         PyEval_SetTrace(nullptr, nullptr);
     else
         PyEval_SetProfile(nullptr, nullptr);

--- a/src/scorepy/cInstrumenter.cpp
+++ b/src/scorepy/cInstrumenter.cpp
@@ -1,6 +1,8 @@
 #include "cInstrumenter.hpp"
 #include "events.hpp"
 #include "pythonHelpers.hpp"
+#include <algorithm>
+#include <array>
 #include <string>
 
 namespace scorepy
@@ -16,10 +18,6 @@ static const std::string& make_region_name(const char* moduleName, const char* n
 
 void CInstrumenter::enable_instrumenter()
 {
-    // TODO: Known issue:  `sys.getprofile()` returns the user object (2nd arg)
-    // So `sys.setprofile(sys.getprofile())` will not round-trip as it will try to call the
-    // 2nd arg. If it is nullptr (here) it means it will be disabled completely
-    // See https://nedbatchelder.com/text/trace-function.html for details
     const auto callback = [](PyObject* obj, PyFrameObject* frame, int what, PyObject* arg) -> int {
         return fromPyObject(obj)->onEvent(*frame, what, arg) ? 0 : -1;
     };
@@ -39,6 +37,34 @@ void CInstrumenter::disable_instrumenter()
         PyEval_SetTrace(nullptr, nullptr);
     else
         PyEval_SetProfile(nullptr, nullptr);
+}
+
+/// Mapping of PyTrace_* to it's string representations
+/// List taken from CPythons sysmodule.c
+static const std::array<std::string, 8> whatStrings = { "call",     "exception", "line",
+                                                        "return",   "c_call",    "c_exception",
+                                                        "c_return", "opcode" };
+
+// Required because:  `sys.getprofile()` returns the user object (2nd arg to PyEval_SetTrace)
+// So `sys.setprofile(sys.getprofile())` will not round-trip as it will try to call the
+// 2nd arg through pythons dispatch function. Hence make the object callable.
+// See https://nedbatchelder.com/text/trace-function.html for details
+PyObject* CInstrumenter::operator()(PyFrameObject& frame, const char* what, PyObject* arg)
+{
+    const auto itWhat = std::find(whatStrings.begin(), whatStrings.end(), what);
+    const int iWhat = itWhat == whatStrings.end() ? -1 : std::distance(whatStrings.begin(), itWhat);
+    // To speed up further event processing install this class directly as the handler
+    // But we might be inside a `sys.settrace` call where the user wanted to set another function
+    // which would then be overwritten here. Hence use the CALL event which avoids the problem
+    if (iWhat == PyTrace_CALL)
+        enable_instrumenter();
+    if (onEvent(frame, iWhat, arg))
+    {
+        Py_INCREF(toPyObject());
+        return toPyObject();
+    }
+    else
+        return nullptr;
 }
 
 bool CInstrumenter::onEvent(PyFrameObject& frame, int what, PyObject*)

--- a/src/scorepy/cInstrumenter.cpp
+++ b/src/scorepy/cInstrumenter.cpp
@@ -67,8 +67,9 @@ static const std::array<std::string, 8> WHAT_STRINGS = { "call",     "exception"
 PyObject* CInstrumenter::operator()(PyFrameObject& frame, const char* what_string, PyObject* arg)
 {
     const auto it_what = std::find(WHAT_STRINGS.begin(), WHAT_STRINGS.end(), what_string);
-    const int what =
-        (it_what == WHAT_STRINGS.end()) ? -1 : std::distance(WHAT_STRINGS.begin(), it_what);
+    int what = -1;
+    if (it_what != WHAT_STRINGS.end())
+        what = std::distance(WHAT_STRINGS.begin(), it_what);
     // To speed up further event processing install this class directly as the handler
     // But we might be inside a `sys.settrace` call where the user wanted to set another function
     // which would then be overwritten here. Hence use the CALL event which avoids the problem

--- a/src/scorepy/cInstrumenter.cpp
+++ b/src/scorepy/cInstrumenter.cpp
@@ -41,7 +41,7 @@ PyObject* CInstrumenter::operator()(PyFrameObject& frame, const char* what_strin
 {
     const auto it_what = std::find(WHAT_STRINGS.begin(), WHAT_STRINGS.end(), what_string);
     const int what =
-        it_what == WHAT_STRINGS.end() ? -1 : std::distance(WHAT_STRINGS.begin(), it_what);
+        (it_what == WHAT_STRINGS.end()) ? -1 : std::distance(WHAT_STRINGS.begin(), it_what);
     // To speed up further event processing install this class directly as the handler
     // But we might be inside a `sys.settrace` call where the user wanted to set another function
     // which would then be overwritten here. Hence use the CALL event which avoids the problem

--- a/src/scorepy/cInstrumenter.cpp
+++ b/src/scorepy/cInstrumenter.cpp
@@ -7,14 +7,6 @@
 
 namespace scorepy
 {
-static const std::string& make_region_name(const char* moduleName, const char* name)
-{
-    static std::string region;
-    region = moduleName;
-    region += ":";
-    region += name;
-    return region;
-}
 
 void CInstrumenter::enable_instrumenter()
 {

--- a/src/scorepy/cInstrumenter.hpp
+++ b/src/scorepy/cInstrumenter.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <Python.h>
+#include <frameobject.h>
+
+namespace scorepy
+{
+struct CInstrumenter
+{
+    PyObject_HEAD;
+    bool tracingOrProfiling;
+
+    void init(bool tracingOrProfiling)
+    {
+        this->tracingOrProfiling = tracingOrProfiling;
+    }
+    void enable_instrumenter();
+    void disable_instrumenter();
+
+    /// These casts are valid as long as `PyObject_HEAD` is the first entry in this struct
+    PyObject* toPyObject()
+    {
+        return reinterpret_cast<PyObject*>(this);
+    }
+    static CInstrumenter* fromPyObject(PyObject* o)
+    {
+        return reinterpret_cast<CInstrumenter*>(o);
+    }
+
+private:
+    /// Callback for Python trace/profile events. Return true for success
+    bool onEvent(PyFrameObject& frame, int what, PyObject* arg);
+};
+
+} // namespace scorepy

--- a/src/scorepy/cInstrumenter.hpp
+++ b/src/scorepy/cInstrumenter.hpp
@@ -5,14 +5,22 @@
 
 namespace scorepy
 {
+/// Interface to Python used to implement an instrumenter
+/// See sys.settrace/setprofile
+enum class InstrumenterInterface
+{
+    Profile,
+    Trace
+};
+
 struct CInstrumenter
 {
     PyObject_HEAD;
-    bool tracing_or_profiling;
+    InstrumenterInterface interface;
 
-    void init(bool tracing_or_profiling)
+    void init(InstrumenterInterface interface)
     {
-        this->tracing_or_profiling = tracing_or_profiling;
+        this->interface = interface;
     }
     void enable_instrumenter();
     void disable_instrumenter();

--- a/src/scorepy/cInstrumenter.hpp
+++ b/src/scorepy/cInstrumenter.hpp
@@ -17,6 +17,9 @@ struct CInstrumenter
     void enable_instrumenter();
     void disable_instrumenter();
 
+    /// Callback for when this object is called directly
+    PyObject* operator()(PyFrameObject& frame, const char* what, PyObject* arg);
+
     /// These casts are valid as long as `PyObject_HEAD` is the first entry in this struct
     PyObject* toPyObject()
     {

--- a/src/scorepy/cInstrumenter.hpp
+++ b/src/scorepy/cInstrumenter.hpp
@@ -8,11 +8,11 @@ namespace scorepy
 struct CInstrumenter
 {
     PyObject_HEAD;
-    bool tracingOrProfiling;
+    bool tracing_or_profiling;
 
-    void init(bool tracingOrProfiling)
+    void init(bool tracing_or_profiling)
     {
-        this->tracingOrProfiling = tracingOrProfiling;
+        this->tracing_or_profiling = tracing_or_profiling;
     }
     void enable_instrumenter();
     void disable_instrumenter();
@@ -21,18 +21,18 @@ struct CInstrumenter
     PyObject* operator()(PyFrameObject& frame, const char* what, PyObject* arg);
 
     /// These casts are valid as long as `PyObject_HEAD` is the first entry in this struct
-    PyObject* toPyObject()
+    PyObject* to_PyObject()
     {
         return reinterpret_cast<PyObject*>(this);
     }
-    static CInstrumenter* fromPyObject(PyObject* o)
+    static CInstrumenter* from_PyObject(PyObject* o)
     {
         return reinterpret_cast<CInstrumenter*>(o);
     }
 
 private:
     /// Callback for Python trace/profile events. Return true for success
-    bool onEvent(PyFrameObject& frame, int what, PyObject* arg);
+    bool on_event(PyFrameObject& frame, int what, PyObject* arg);
 };
 
 } // namespace scorepy

--- a/src/scorepy/cInstrumenter.hpp
+++ b/src/scorepy/cInstrumenter.hpp
@@ -17,11 +17,11 @@ struct CInstrumenter
 {
     PyObject_HEAD;
     InstrumenterInterface interface;
+    PyObject* threading_module;
+    PyObject* threading_set_instrumenter;
 
-    void init(InstrumenterInterface interface)
-    {
-        this->interface = interface;
-    }
+    void init(InstrumenterInterface interface);
+    void deinit();
     void enable_instrumenter();
     void disable_instrumenter();
 

--- a/src/scorepy/events.hpp
+++ b/src/scorepy/events.hpp
@@ -5,6 +5,17 @@
 
 namespace scorepy
 {
+/// Combine the arguments into a region name
+/// Return value is a statically allocated string to avoid memory (re)allocations
+inline const std::string& make_region_name(const char* module_name, const char* name)
+{
+    static std::string region;
+    region = module_name;
+    region += ":";
+    region += name;
+    return region;
+}
+
 void region_begin(const std::string& region_name, std::string module, std::string file_name,
                   std::uint64_t line_number);
 void region_end(const std::string& region_name);

--- a/src/scorepy/pythonHelpers.cpp
+++ b/src/scorepy/pythonHelpers.cpp
@@ -12,7 +12,7 @@ const char* get_module_name(const PyFrameObject& frame)
     // this is a NUMPY special situation, see NEP-18, and Score-P issue #63
     // TODO: Use string_view/C-String to avoid creating 2 std::strings
     const char* filename = PyUnicode_AsUTF8(frame.f_code->co_filename);
-    if (filename && std::string(filename) == "<__array_function__ internals>")
+    if (filename && (std::string(filename) == "<__array_function__ internals>"))
         return "numpy.__array_function__";
     else
         return "unkown";

--- a/src/scorepy/pythonHelpers.cpp
+++ b/src/scorepy/pythonHelpers.cpp
@@ -5,9 +5,9 @@ namespace scorepy
 {
 const char* get_module_name(const PyFrameObject& frame)
 {
-    PyObject* moduleName = PyDict_GetItemString(frame.f_globals, "__name__");
-    if (moduleName)
-        return PyUnicode_AsUTF8(moduleName);
+    PyObject* module_name = PyDict_GetItemString(frame.f_globals, "__name__");
+    if (module_name)
+        return PyUnicode_AsUTF8(module_name);
 
     // this is a NUMPY special situation, see NEP-18, and Score-P issue #63
     // TODO: Use string_view/C-String to avoid creating 2 std::strings
@@ -20,11 +20,11 @@ const char* get_module_name(const PyFrameObject& frame)
 
 std::string get_file_name(const PyFrameObject& frame)
 {
-    PyObject* fileName = frame.f_code->co_filename;
-    if (fileName == Py_None)
+    PyObject* filename = frame.f_code->co_filename;
+    if (filename == Py_None)
         return "None";
-    char actualpath[PATH_MAX];
-    const char* full_file_name = realpath(PyUnicode_AsUTF8(fileName), actualpath);
+    char actual_path[PATH_MAX];
+    const char* full_file_name = realpath(PyUnicode_AsUTF8(filename), actual_path);
     return full_file_name ? full_file_name : "ErrorPath";
 }
 } // namespace scorepy

--- a/src/scorepy/pythonHelpers.cpp
+++ b/src/scorepy/pythonHelpers.cpp
@@ -22,7 +22,9 @@ std::string get_file_name(const PyFrameObject& frame)
 {
     PyObject* filename = frame.f_code->co_filename;
     if (filename == Py_None)
+    {
         return "None";
+    }
     char actual_path[PATH_MAX];
     const char* full_file_name = realpath(PyUnicode_AsUTF8(filename), actual_path);
     return full_file_name ? full_file_name : "ErrorPath";

--- a/src/scorepy/pythonHelpers.cpp
+++ b/src/scorepy/pythonHelpers.cpp
@@ -1,0 +1,30 @@
+#include "pythonHelpers.hpp"
+#include <stdlib.h>
+
+namespace scorepy
+{
+const char* get_module_name(const PyFrameObject& frame)
+{
+    PyObject* moduleName = PyDict_GetItemString(frame.f_globals, "__name__");
+    if (moduleName)
+        return PyUnicode_AsUTF8(moduleName);
+
+    // this is a NUMPY special situation, see NEP-18, and Score-P issue #63
+    // TODO: Use string_view/C-String to avoid creating 2 std::strings
+    const char* filename = PyUnicode_AsUTF8(frame.f_code->co_filename);
+    if (filename && std::string(filename) == "<__array_function__ internals>")
+        return "numpy.__array_function__";
+    else
+        return "unkown";
+}
+
+std::string get_file_name(const PyFrameObject& frame)
+{
+    PyObject* fileName = frame.f_code->co_filename;
+    if (fileName == Py_None)
+        return "None";
+    char actualpath[PATH_MAX];
+    const char* full_file_name = realpath(PyUnicode_AsUTF8(fileName), actualpath);
+    return full_file_name ? full_file_name : "ErrorPath";
+}
+} // namespace scorepy

--- a/src/scorepy/pythonHelpers.hpp
+++ b/src/scorepy/pythonHelpers.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <Python.h>
+#include <frameobject.h>
+#include <string>
+
+namespace scorepy
+{
+
+struct retain_object_t
+{
+};
+struct adopt_object_t
+{
+};
+/// Marker to indicate that an owner is added, i.e. refCnt is increased
+constexpr retain_object_t retain_object{};
+/// Marker to take over ownership, not touching the refCnt
+constexpr adopt_object_t adopt_object{};
+
+/// Slim, owning wrapper over a PyObject*
+/// Decays implictely to a PyObject*
+class PyRefObject
+{
+    PyObject* o_;
+
+public:
+    explicit PyRefObject(PyObject* o, adopt_object_t) noexcept : o_(o)
+    {
+    }
+    explicit PyRefObject(PyObject* o, retain_object_t) noexcept : o_(o)
+    {
+        Py_XINCREF(o_);
+    }
+    PyRefObject(PyRefObject&& rhs) noexcept : o_(rhs.o_)
+    {
+        rhs.o_ = nullptr;
+    }
+    PyRefObject& operator=(PyRefObject&& rhs) noexcept
+    {
+        o_ = rhs.o_;
+        rhs.o_ = nullptr;
+        return *this;
+    }
+    ~PyRefObject() noexcept
+    {
+        Py_XDECREF(o_);
+    }
+
+    operator PyObject*() const noexcept
+    {
+        return o_;
+    }
+};
+
+/// Return the module name the frame belongs to.
+/// The pointer is valid for the lifetime of the frame
+const char* get_module_name(const PyFrameObject& frame);
+/// Return the file name the frame belongs to
+std::string get_file_name(const PyFrameObject& frame);
+
+} // namespace scorepy

--- a/src/scorepy/pythonHelpers.hpp
+++ b/src/scorepy/pythonHelpers.hpp
@@ -66,7 +66,7 @@ namespace detail
 /// Cast a function pointer to a python-bindings compatible function pointer
 /// Replaces all Foo* by PyObject* for all types Foo that are PyObject compatible
 template <typename TFunc>
-auto castToPyFunc(TFunc* func) -> detail::ReplaceArgsToPyObject_t<TFunc>*
+auto cast_to_PyFunc(TFunc* func) -> detail::ReplaceArgsToPyObject_t<TFunc>*
 {
     return reinterpret_cast<detail::ReplaceArgsToPyObject_t<TFunc>*>(func);
 }
@@ -99,7 +99,7 @@ namespace detail
     };
 
     template <class T>
-    struct IsPyObject<T, void_t<decltype(std::declval<T>().toPyObject())>> : std::true_type
+    struct IsPyObject<T, void_t<decltype(std::declval<T>().to_PyObject())>> : std::true_type
     {
     };
 

--- a/test/cases/use_threads.py
+++ b/test/cases/use_threads.py
@@ -1,0 +1,22 @@
+import random
+import threading
+import time
+import instrumentation2
+
+
+def worker(id, func):
+    print("Thread %s started" % id)
+    # Use a random delay to add non-determinism to the output
+    time.sleep(random.uniform(0.01, 0.9))
+    func()
+
+
+def foo():
+    print("hello world")
+    t1 = threading.Thread(target=worker, args=(0, instrumentation2.bar))
+    t2 = threading.Thread(target=worker, args=(1, instrumentation2.baz))
+    t1.start()
+    t2.start()
+
+
+foo()

--- a/test/cases/use_threads.py
+++ b/test/cases/use_threads.py
@@ -17,6 +17,8 @@ def foo():
     t2 = threading.Thread(target=worker, args=(1, instrumentation2.baz))
     t1.start()
     t2.start()
+    t1.join()
+    t2.join()
 
 
 foo()

--- a/test/test_scorep.py
+++ b/test/test_scorep.py
@@ -308,9 +308,11 @@ def test_threads(scorep_env, instrumenter):
                                         env=scorep_env)
 
     # assert std_err == "" TODO: Readd when issue #87 is resolved
-    assert re.search(("hello world\n" +
-                      "(Thread 0 started\nThread 1 started\n|Thread 1 started\nThread 0 started\n)" +
-                      "(baz\nbar\n|bar\nbaz\n)"), std_out)
+    assert "hello world\n" in std_out
+    assert "Thread 0 started\n" in std_out
+    assert "Thread 1 started\n" in std_out
+    assert "bar\n" in std_out
+    assert "baz\n" in std_out
 
     std_out, std_err = call(["otf2-print", trace_path])
 


### PR DESCRIPTION
This implements the ScorepProfile/ScorepTrace classes in C by pretty much 1:1 translating the Python code to C.

To handle tracing of threads created by `threading` the object itself is passed to `threading.settrace` and made callable. On invocation the arguments are converted to C types and passed to the regular C callback. To avoid the overhead of first going through Python code for each event the C callback is then installed directly.

A few helper methods are realized in pythonUtils, one of them being `castToPyFunc` which allows to cast function pointers like `void (CInstrumenter*)` to `void(PyObject*)` generically which provides greater safety against passing a mismatching type. The other notable helper is a class `PyRefObject` which is a stripped down unique_ptr specific to Python that allows to transfer/adopt or retain ownership over the python object and implicit decay to `PyObject*` removing some boilerplate code. It is modeled after the `retain_ptr` concept proposed for inclusion into the C++ standard (except for the decay)

I also renamed the C extension `_bindings` to make it private and avoid the duplication in `scorep.scorep_bindings` (now: `scorep._bindings`)