### PR TITLE
Don't use exceptions when checking for existing region

### DIFF
--- a/src/scorepy/events.cpp
+++ b/src/scorepy/events.cpp
@@ -35,12 +35,12 @@ void region_begin(const std::string& region_name, std::string module, std::strin
 
 void region_end(const std::string& region_name)
 {
-    try
+    const auto itRegion = regions.find(region_name);
+    if (itRegion != regions.end())
     {
-        auto& handle = regions.at(region_name);
-        SCOREP_User_RegionEnd(handle.value);
+        SCOREP_User_RegionEnd(itRegion->second.value);
     }
-    catch (std::out_of_range& e)
+    else
     {
         static region_handle error_region;
         static SCOREP_User_ParameterHandle scorep_param = SCOREP_USER_INVALID_PARAMETER;


### PR DESCRIPTION
This slightly improves performance in general and potentially a lot for the error case. 

Reasoning: `at` will most likely call `find`, check for `end()` and raise an exception or return the value. Hence the new code is equivalent for the "happy path" and faster for the error path as a simple `Jump` is executed instead of the heavy allocate-throw-catch-stack_unwind  that is required for the exception handling path

Also compilers often don't optimize exception handling code well, so this might have optimization improvements too.