### PR TITLE
Avoid inplace construction if its not needed

### DIFF
--- a/src/scorepy/events.cpp
+++ b/src/scorepy/events.cpp
@@ -20,9 +20,15 @@ static std::unordered_map<std::string, region_handle> rewind_regions;
 void region_begin(const std::string& region_name, std::string module, std::string file_name,
                   std::uint64_t line_number)
 {
-    auto pair = regions.emplace(make_pair(region_name, region_handle()));
-    bool inserted_new = pair.second;
-    auto& handle = pair.first->second;
+	auto region_it = regions.find(region_name);
+	bool inserted_new = false;
+	if (region_it == regions.end())
+	{
+		region_it = regions.emplace(make_pair(region_name, region_handle())).first;
+		inserted_new = true;
+	}
+
+    auto& handle = region_it->second;
     if (inserted_new)
     {
         SCOREP_User_RegionInit(&handle.value, NULL, &SCOREP_User_LastFileHandle,

--- a/src/scorepy/events.cpp
+++ b/src/scorepy/events.cpp
@@ -21,7 +21,7 @@ void region_begin(const std::string& region_name, std::string module, std::strin
                   std::uint64_t line_number)
 {
     auto region_it = regions.find(region_name);
-	bool inserted_new = false;
+    bool inserted_new = false;
     if (region_it == regions.end())
     {
         region_it = regions.emplace(make_pair(region_name, region_handle())).first;

--- a/src/scorepy/events.cpp
+++ b/src/scorepy/events.cpp
@@ -22,11 +22,11 @@ void region_begin(const std::string& region_name, std::string module, std::strin
 {
     auto region_it = regions.find(region_name);
 	bool inserted_new = false;
-	if (region_it == regions.end())
-	{
-		region_it = regions.emplace(make_pair(region_name, region_handle())).first;
-		inserted_new = true;
-	}
+    if (region_it == regions.end())
+    {
+        region_it = regions.emplace(make_pair(region_name, region_handle())).first;
+        inserted_new = true;
+    }
 
     auto& handle = region_it->second;
     if (inserted_new)

--- a/src/scorepy/events.cpp
+++ b/src/scorepy/events.cpp
@@ -20,7 +20,7 @@ static std::unordered_map<std::string, region_handle> rewind_regions;
 void region_begin(const std::string& region_name, std::string module, std::string file_name,
                   std::uint64_t line_number)
 {
-	auto region_it = regions.find(region_name);
+    auto region_it = regions.find(region_name);
 	bool inserted_new = false;
 	if (region_it == regions.end())
 	{

--- a/src/scorepy/events.cpp
+++ b/src/scorepy/events.cpp
@@ -20,16 +20,8 @@ static std::unordered_map<std::string, region_handle> rewind_regions;
 void region_begin(const std::string& region_name, std::string module, std::string file_name,
                   std::uint64_t line_number)
 {
-    auto region_it = regions.find(region_name);
-    bool inserted_new = false;
-    if (region_it == regions.end())
-    {
-        region_it = regions.emplace(make_pair(region_name, region_handle())).first;
-        inserted_new = true;
-    }
-
-    auto& handle = region_it->second;
-    if (inserted_new)
+    auto& handle = regions[region_name];
+    if (handle.value == SCOREP_USER_INVALID_REGION)
     {
         SCOREP_User_RegionInit(&handle.value, NULL, &SCOREP_User_LastFileHandle,
                                region_name.c_str(), SCOREP_USER_REGION_TYPE_FUNCTION,

--- a/src/scorepy/events.cpp
+++ b/src/scorepy/events.cpp
@@ -7,9 +7,8 @@
 namespace scorepy
 {
 
-class region_handle
+struct region_handle
 {
-public:
     constexpr region_handle() = default;
     ~region_handle() = default;
     constexpr bool operator==(const region_handle& other)


### PR DESCRIPTION
The `std::unordered_map<Key,T,Hash,KeyEqual,Allocator>::emplace` doc states:

> The element may be constructed even if there already is an element with the key in the container, in which case the newly constructed element will be destroyed immediately.

As we addressed #94 we could address this here as well. We should change to `try_emplace`, once we change to c++17. 