### PR TITLE
Add whitelist of regions with no region enter events

### DIFF
--- a/src/scorepy/events.cpp
+++ b/src/scorepy/events.cpp
@@ -1,4 +1,5 @@
 #include "events.hpp"
+#include <Python.h>
 #include <algorithm>
 #include <array>
 #include <iostream>
@@ -37,8 +38,13 @@ void region_begin(const std::string& region_name, std::string module, std::strin
 
 /// Region names that are known to have no region enter event and should not report an error
 /// on region exit
-static const std::array<std::string, 2> EXIT_REGION_WHITELIST = { "threading:_bootstrap_inner",
-                                                                  "threading:_bootstrap" };
+static const std::array<std::string, 2> EXIT_REGION_WHITELIST = {
+#if PY_MAJOR_VERSION >= 3
+    "threading:_bootstrap_inner", "threading:_bootstrap"
+#else
+    "threading:__bootstrap_inner", "threading:__bootstrap"
+#endif
+};
 
 void region_end(const std::string& region_name)
 {

--- a/test/test_scorep.py
+++ b/test/test_scorep.py
@@ -307,7 +307,7 @@ def test_threads(scorep_env, instrumenter):
                                         ["--nocompiler",  "--instrumenter-type=" + instrumenter],
                                         env=scorep_env)
 
-    # assert std_err == "" TODO: Readd when issue #87 is resolved
+    assert std_err == ""
     assert "hello world\n" in std_out
     assert "Thread 0 started\n" in std_out
     assert "Thread 1 started\n" in std_out


### PR DESCRIPTION
Avoids confusing warning when it is known that no region enter event can
be recorded. This is true for the threading::bootstrap methods as they
are called right after creating a new thread but before the instrumenter is enabled

Fixes #87