### PR TITLE
Improve readability of benchmark script and fix CInstrumenter benchmark

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -7,20 +7,29 @@ import sys
 import benchmark_helper
 import pickle
 
-bench = benchmark_helper.BenchmarkEnv(repetitions=51)
 tests = ["bm_baseline.py", "bm_simplefunc.py"]
+
+instrumenters = ["profile", "trace", "dummy", "None"]
+if sys.version_info.major >= 3:
+    instrumenters.extend(["cProfile", "cTrace"])
+
+# How many times the instrumented code is run during 1 test run
+reps_x = {
+    "bm_baseline.py": ["1000000", "2000000", "3000000", "4000000", "5000000"],
+    "bm_simplefunc.py": ["100000", "200000", "300000", "400000", "500000"],
+}
+# How many times a test invocation is repeated (number of timings per test instance)
+test_repetitions = 51
+
+bench = benchmark_helper.BenchmarkEnv(repetitions=test_repetitions)
 results = {}
 
-reps_x = {}
-reps_x["bm_baseline.py"] = ["1000000", "2000000", "3000000", "4000000", "5000000"]
-reps_x["bm_simplefunc.py"] = ["100000", "200000", "300000", "400000", "500000"]
-
 for test in tests:
-    results[test] = {"profile": {}, "trace": {}, "dummy": {}, "None": {}}
-    if sys.version_info.major >= 3:
-        results[test].update({"cProfile": {}, "cTrace": {}})
+    results[test] = {}
 
-    for instrumenter in results[test]:
+    for instrumenter in instrumenters:
+        results[test][instrumenter] = {}
+
         if instrumenter == "None":
             enable_scorep = False
             scorep_settings = []
@@ -35,8 +44,8 @@ for test in tests:
             times = bench.call(test, [reps],
                                enable_scorep,
                                scorep_settings=scorep_settings)
-            results[test][instrumenter][reps] = times
             print("{:<8}: {}".format(reps, times))
+            results[test][instrumenter][reps] = times
 
 with open("results.pkl", "wb") as f:
     pickle.dump(results, f)

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -18,7 +18,7 @@ reps_x["bm_simplefunc.py"] = ["100000", "200000", "300000", "400000", "500000"]
 for test in tests:
     results[test] = {"profile": {}, "trace": {}, "dummy": {}, "None": {}}
     if sys.version_info.major >= 3:
-        results.update({"cProfile": {}, "cTrace": {}})
+        results[test].update({"cProfile": {}, "cTrace": {}})
 
     for instrumenter in results[test]:
         if instrumenter == "None":

--- a/benchmark/benchmark_helper.py
+++ b/benchmark/benchmark_helper.py
@@ -36,18 +36,16 @@ class BenchmarkEnv():
             arguments.extend(scorep_settings)
         arguments.append(script)
         arguments.extend(ops)
+        print(arguments)
 
         runtimes = []
-        for i in range(self.repetitions):
+        for _ in range(self.repetitions):
             begin = time.time()
-            print(arguments)
             out = subprocess.run(
                 arguments,
-                env=self.env,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE)
+                env=self.env)
             end = time.time()
-            assert(out.returncode == 0)
+            assert out.returncode == 0
 
             runtime = end - begin
             runtimes.append(runtime)


### PR DESCRIPTION
I found a bug which was probably introduced when resolving some conflicts after a rebase where the CInstrumenters were added at the "test name" level in the results dict and hence never used. This is fixed in the first commit to highlight this.

To avoid things like this in the future I refactored the Benchmark to make it more readable.
- First define the benchmark parameters: tests, instrumenters, repetitions (with comments which is what)
- Then setup benchmark and results
- Add each sub-dict at the corresponding loop level

Similar 3 small changes to the "benchmark_helper":
- variable name `i` not required hence replaced by underscore per Python convention
- braces in assert statement not required
- PIPEs not required
- print invocation params only once, not 51 times which improves readability of the output and it does not include the invocation time of print in the timing

So no functional changes (if you don't count the repeated print) but only a general refactoring improving readability fixing a bug found by that. I can split this further if required but I think it belongs together and splitting it may cause conflicts due to the small file size