### PR TITLE
 Create benchmark_dir as unique directory in /tmp and cleanup after completion

### DIFF
--- a/benchmark/benchmark_helper.py
+++ b/benchmark/benchmark_helper.py
@@ -1,8 +1,9 @@
 import subprocess
 import os
-import shutil
+#import shutil
 import sys
 import time
+import tempfile
 
 
 class BenchmarkEnv():
@@ -12,13 +13,8 @@ class BenchmarkEnv():
         self.env["SCOREP_ENABLE_TRACING"] = "false"
         self.env["SCOREP_PROFILING_MAX_CALLPATH_DEPTH"] = "98"
         self.env["SCOREP_TOTAL_MEMORY"] = "3G"
-        self.exp_dir = "benchmark_dir"
+        self.exp_dir = tempfile.mkdtemp(prefix="benchmark_dir_")
         self.repetitions = repetitions
-
-        shutil.rmtree(
-            self.exp_dir,
-            ignore_errors=True)
-        os.mkdir(self.exp_dir)
 
     def __del__(self):
         pass

--- a/benchmark/benchmark_helper.py
+++ b/benchmark/benchmark_helper.py
@@ -1,6 +1,6 @@
 import subprocess
 import os
-#import shutil
+import shutil
 import sys
 import time
 import tempfile
@@ -17,10 +17,9 @@ class BenchmarkEnv():
         self.repetitions = repetitions
 
     def __del__(self):
-        pass
-#         shutil.rmtree(
-#             self.exp_dir,
-#             ignore_errors=True)
+        shutil.rmtree(
+            self.exp_dir,
+            ignore_errors=True)
 
     def call(self, script="", ops=[], enable_scorep=True, scorep_settings=[]):
         self.env["SCOREP_EXPERIMENT_DIRECTORY"] = self.exp_dir + \


### PR DESCRIPTION
Currently the scorep data is placed in many folders in the current directory and left there although I don't see a use for them.

Using /tmp for this folder may use a faster filesystem on taurus increasing the accuracy of the measurement and using the tempfile module makes sure that directory is created and fresh/empty

I also re-enabled the code that removes the folder after completion so no artifacts remain on the disk.

Could split into 2 PRs but those seem small and related enough to not warrant the additional work on creation and review.