### PR TITLE
Fix spurious MPI test failure

### DIFF
--- a/test/test_scorep.py
+++ b/test/test_scorep.py
@@ -250,10 +250,11 @@ def test_mpi(scorep_env, instrumenter):
                              "cases/mpi.py"],
                             env=scorep_env)
 
-    expected_std_out = r"\[0[0-9]\] \[0. 1. 2. 3. 4.\]\n\[0[0-9]] \[0. 1. 2. 3. 4.\]\n"
-
     assert re.search(r'\[Score-P\] [\w/.: ]*MPI_THREAD_FUNNELED', std_err)
-    assert re.search(expected_std_out, std_out)
+    assert '[00] [0. 1. 2. 3. 4.]\n' in std_out
+    assert '[01] [0. 1. 2. 3. 4.]\n' in std_out
+    assert 'bar\n' in std_out
+    assert 'baz\n' in std_out
 
     std_out, std_err = call(["otf2-print", trace_path])
 


### PR DESCRIPTION
It can happen that the output of the numpy array from each rank and its output from the bar/baz function get interleaved.
However the current test checks for contiguous output

These new checks are better:
- They also check for the rank
- They don't require a specific order
- They fix a small issue with the regex which allowed any character for the dot while it should be a literal dot