### PR TITLE
Implement CString as a wrapper around a C-String to avoid using std::string

### DIFF
--- a/src/methods.cpp
+++ b/src/methods.cpp
@@ -1,6 +1,7 @@
 #include "methods.hpp"
 #include "scorepy/events.hpp"
 #include "scorepy/pathUtils.hpp"
+#include "scorepy/pythonHelpers.hpp"
 #include <Python.h>
 #include <cstdint>
 #include <scorep/SCOREP_User_Functions.h>
@@ -30,19 +31,20 @@ extern "C"
      */
     static PyObject* region_begin(PyObject* self, PyObject* args)
     {
-        const char* module;
-        const char* function_name;
-        const char* file_name;
+        scorepy::PythonCString module;
+        scorepy::PythonCString function_name;
+        scorepy::PythonCString file_name;
         PyObject* identifier = nullptr;
         std::uint64_t line_number = 0;
 
-        if (!PyArg_ParseTuple(args, "sssKO", &module, &function_name, &file_name, &line_number,
+        if (!PyArg_ParseTuple(args, "s#s#s#KO", &module.s, &module.l, &function_name.s,
+                              &function_name.l, &file_name.s, &file_name.l, &line_number,
                               &identifier))
         {
             return NULL;
         }
 
-        if (identifier == nullptr or identifier == Py_None)
+        if (identifier == Py_None)
         {
             scorepy::region_begin(function_name, module, file_name, line_number);
         }
@@ -60,16 +62,17 @@ extern "C"
      */
     static PyObject* region_end(PyObject* self, PyObject* args)
     {
-        const char* module;
-        const char* function_name;
+        scorepy::PythonCString module;
+        scorepy::PythonCString function_name;
         PyObject* identifier = nullptr;
 
-        if (!PyArg_ParseTuple(args, "ssO", &module, &function_name, &identifier))
+        if (!PyArg_ParseTuple(args, "s#s#O", &module.s, &module.l, &function_name.s,
+                              &function_name.l, &identifier))
         {
             return NULL;
         }
 
-        if (identifier == nullptr or identifier == Py_None)
+        if (identifier == Py_None)
         {
             scorepy::region_end(function_name, module);
         }

--- a/src/scorepy/cstring.h
+++ b/src/scorepy/cstring.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <cassert>
+#include <cstring>
+
+namespace scorepy
+{
+
+/// Thin wrapper around a C-String (NULL-terminated sequence of chars)
+class CString
+{
+    const char* s_;
+    size_t len_;
+
+public:
+    template <size_t N>
+    constexpr CString(const char (&s)[N]) : s_(s), len_(N - 1u)
+    {
+        static_assert(N > 0, "Cannot handle empty char array");
+    }
+
+    explicit CString(const char* s, size_t len) : s_(s), len_(len)
+    {
+        assert(s_);
+    }
+
+    explicit CString(const char* s) : s_(s), len_(std::strlen(s_))
+    {
+        assert(s_);
+    }
+
+    constexpr const char* c_str() const
+    {
+        return s_;
+    }
+    /// Find the first occurrence of the character and return a pointer to it or NULL if not found
+    const char* find(char c) const
+    {
+        return static_cast<const char*>(std::memchr(s_, c, len_));
+    }
+    template <size_t N>
+    bool starts_with(const char (&prefix)[N]) const
+    {
+        return (len_ >= N - 1u) && (std::memcmp(s_, prefix, N - 1u) == 0);
+    }
+
+    friend bool operator==(const CString& lhs, const CString& rhs)
+    {
+        return (lhs.len_ == rhs.len_) && (std::memcmp(lhs.s_, rhs.s_, rhs.len_) == 0);
+    }
+    friend bool operator!=(const CString& lhs, const CString& rhs)
+    {
+        return !(lhs == rhs);
+    }
+};
+
+} // namespace scorepy

--- a/src/scorepy/events.hpp
+++ b/src/scorepy/events.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "cstring.h"
 #include <cstdint>
 #include <string>
 
@@ -7,24 +8,22 @@ namespace scorepy
 {
 /// Combine the arguments into a region name
 /// Return value is a statically allocated string to avoid memory (re)allocations
-inline const std::string& make_region_name(const std::string& module_name, const std::string& name)
+inline const std::string& make_region_name(const CString module_name, const CString name)
 {
     static std::string region;
-    region = module_name;
+    region = module_name.c_str();
     region += ":";
-    region += name;
+    region += name.c_str();
     return region;
 }
 
-void region_begin(const std::string& function_name, const std::string& module,
-                  const std::string& file_name, const std::uint64_t line_number,
-                  const std::uintptr_t& identifier);
-void region_begin(const std::string& function_name, const std::string& module,
-                  const std::string& file_name, const std::uint64_t line_number);
+void region_begin(CString function_name, CString module, CString file_name,
+                  const std::uint64_t line_number, const std::uintptr_t& identifier);
+void region_begin(CString function_name, CString module, CString file_name,
+                  const std::uint64_t line_number);
 
-void region_end(const std::string& function_name, const std::string& module,
-                const std::uintptr_t& identifier);
-void region_end(const std::string& function_name, const std::string& module);
+void region_end(CString function_name, CString module, const std::uintptr_t& identifier);
+void region_end(CString function_name, CString module);
 
 void region_end_error_handling(const std::string& region_name);
 

--- a/src/scorepy/pythonHelpers.cpp
+++ b/src/scorepy/pythonHelpers.cpp
@@ -4,22 +4,25 @@
 
 namespace scorepy
 {
-const char* get_module_name(const PyFrameObject& frame)
+CString get_module_name(const PyFrameObject& frame)
 {
     PyObject* module_name = PyDict_GetItemString(frame.f_globals, "__name__");
     if (module_name)
-        return PyUnicode_AsUTF8(module_name);
+        return get_string_from_python(*module_name);
 
     // this is a NUMPY special situation, see NEP-18, and Score-P issue #63
-    // TODO: Use string_view/C-String to avoid creating 2 std::strings
-    const char* filename = PyUnicode_AsUTF8(frame.f_code->co_filename);
-    if (filename && (std::string(filename) == "<__array_function__ internals>"))
+    const CString filename = get_string_from_python(*frame.f_code->co_filename);
+    if (filename == "<__array_function__ internals>")
+    {
         return "numpy.__array_function__";
+    }
     else
+    {
         return "unkown";
+    }
 }
 
-std::string get_file_name(const PyFrameObject& frame)
+CString get_file_name(const PyFrameObject& frame)
 {
     PyObject* filename = frame.f_code->co_filename;
     if (filename == Py_None)
@@ -27,6 +30,6 @@ std::string get_file_name(const PyFrameObject& frame)
         return "None";
     }
     const std::string full_file_name = abspath(PyUnicode_AsUTF8(filename));
-    return !full_file_name.empty() ? full_file_name : "ErrorPath";
+    return !full_file_name.empty() ? CStrubg(full_file_name) : CString("ErrorPath");
 }
 } // namespace scorepy

--- a/src/scorepy/pythonHelpers.hpp
+++ b/src/scorepy/pythonHelpers.hpp
@@ -75,9 +75,14 @@ auto cast_to_PyFunc(TFunc* func) -> detail::ReplaceArgsToPyObject_t<TFunc>*
 
 inline CString get_string_from_python(PyObject& o)
 {
+#if PY_MAJOR_VERSION >= 3
     Py_ssize_t len;
     const char* s = PyUnicode_AsUTF8AndSize(&o, &len);
     return CString(s, len);
+#else
+    const char* s = PyString_AsString(&o);
+    return CString(s);
+#endif
 }
 
 /// Pair of a C-String and it's length useful for PyArg_ParseTuple with 's#'


### PR DESCRIPTION
This avoids unnecessary memory allocations by wrapping the raw pointer (and the length).

I did some experiments using the 2 Benchmark PRs and the simpleFunc BM.

Master:
```
 100000: Range=1.1948-1.6665 Mean=1.3541 Median=1.3415
1000000: Range=6.1907-6.8819 Mean=6.4104 Median=6.3628
```

CString w/o length:
```
  100000: Range=1.1841-1.5298 Mean=1.3112 Median=1.3075
 1000000: Range=5.9802-6.4112 Mean=6.1600 Median=6.1523
```

CString w/ length:
```
 100000: Range=1.0298-1.6591 Mean=1.2913 Median=1.2709
1000000: Range=5.8449-6.4538 Mean=6.1164 Median=6.1250
```

CString w/ length and mem* functions:
```
 100000: Range=1.1546-1.5333 Mean=1.3124 Median=1.3039
1000000: Range=5.7451-6.4505 Mean=6.0884 Median=6.0576
```

So yes it does get faster although the effect in this limited scenario is limited.