### PR TITLE
Add C++ implementation of os.path.abspath and use in CInstrumenter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,12 @@ Python_add_library(_bindings
   src/methods.cpp src/scorep_bindings.cpp src/scorepy/events.cpp
 )
 if(Python_VERSION_MAJOR GREATER_EQUAL 3)
-  target_sources(_bindings PRIVATE src/classes.cpp src/scorepy/cInstrumenter.cpp src/scorepy/pythonHelpers.cpp)
+  target_sources(_bindings PRIVATE
+    src/classes.cpp
+    src/scorepy/cInstrumenter.cpp
+    src/scorepy/pathUtils.cpp
+    src/scorepy/pythonHelpers.cpp
+  )
 endif()
 target_link_libraries(_bindings PRIVATE Scorep::Plugin)
 target_compile_features(_bindings PRIVATE cxx_std_11)
@@ -45,6 +50,9 @@ if(ENV{PYTHONPATH})
   string(PREPEND pythonPath "$ENV{PYTHONPATH}:")
 endif()
 set_tests_properties(ScorepPythonTests PROPERTIES ENVIRONMENT "PYTHONPATH=${pythonPath}")
+add_executable(CppTests test/test_pathUtils.cpp src/scorepy/pathUtils.cpp)
+target_include_directories(CppTests PRIVATE src)
+add_test(NAME CppTests COMMAND CppTests)
 
 set(INSTALL_DIR "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,12 @@ src_folder = os.path.abspath('src')
 include += [src_folder]
 sources = ['src/methods.cpp', 'src/scorep_bindings.cpp', 'src/scorepy/events.cpp']
 if sys.version_info.major >= 3:
-    sources.extend(['src/classes.cpp', 'src/scorepy/cInstrumenter.cpp', 'src/scorepy/pythonHelpers.cpp'])
+    sources.extend([
+        'src/classes.cpp',
+        'src/scorepy/cInstrumenter.cpp',
+        'src/scorepy/pythonHelpers.cpp',
+        'src/scorepy/pathUtils.cpp',
+    ])
 
 cmodules.append(Extension('scorep._bindings',
                           include_dirs=include,

--- a/src/scorepy/pathUtils.cpp
+++ b/src/scorepy/pathUtils.cpp
@@ -1,0 +1,92 @@
+#include "pathUtils.hpp"
+#include <cerrno>
+#include <limits>
+#include <unistd.h>
+
+namespace scorepy
+{
+static std::string getcwd()
+{
+    std::string result;
+    const char* cwd;
+    constexpr size_t chunk_size = 512;
+    do
+    {
+        const size_t new_size = result.size() + chunk_size;
+        if (new_size > std::numeric_limits<int>::max())
+        {
+            cwd = nullptr;
+            break;
+        }
+        result.resize(new_size);
+        cwd = ::getcwd(&result.front(), result.size());
+    } while (!cwd && errno == ERANGE);
+    if (cwd)
+        result.resize(result.find('\0', result.size() - chunk_size));
+    else
+        result.clear();
+    return result;
+}
+
+void normalize_path(std::string& path)
+{
+    // 2 slashes are kept, 1 or more than 2 become 1 according to POSIX
+    const size_t num_slashes = (path.find_first_not_of('/') == 2) ? 2 : 1;
+    const size_t path_len = path.size();
+    size_t cur_out = num_slashes;
+    for (size_t i = cur_out; i != path_len + 1; ++i)
+    {
+        if (i == path_len || path[i] == '/')
+        {
+            const char prior = path[cur_out - 1];
+            if (prior == '/') // Double slash -> ignore
+                continue;
+            if (prior == '.')
+            {
+                const char second_prior = path[cur_out - 2];
+                if (second_prior == '/') // '/./'
+                {
+                    --cur_out;
+                    continue;
+                }
+                else if (second_prior == '.' && path[cur_out - 3] == '/') // '/../'
+                {
+                    if (cur_out < 3 + num_slashes) // already behind root slash
+                        cur_out -= 2;
+                    else
+                    {
+                        const auto prior_slash = path.rfind('/', cur_out - 4);
+                        cur_out = prior_slash + 1;
+                    }
+                    continue;
+                }
+            }
+            if (i == path_len)
+                break;
+        }
+        path[cur_out++] = path[i];
+    }
+    // Remove trailing slash
+    if (cur_out > num_slashes && path[cur_out - 1] == '/')
+        --cur_out;
+    path.resize(cur_out);
+}
+
+std::string abspath(const char* input_path)
+{
+    std::string result;
+    if (input_path[0] != '/')
+    {
+        result = getcwd();
+        // On error exit
+        if (result.empty())
+            return result;
+        // Prepend CWD
+        result.append(1, '/').append(input_path);
+    }
+    else
+        result = input_path;
+    normalize_path(result);
+    return result;
+}
+} // namespace scorepy

--- a/src/scorepy/pathUtils.hpp
+++ b/src/scorepy/pathUtils.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <string>
+
+namespace scorepy
+{
+/// A//B, A/./B and A/foo/../B all become A/B
+/// Assumes an absolute, non-empty path
+void normalize_path(std::string& path);
+/// Makes the path absolute and normalized, see Python os.path.abspath
+std::string abspath(const char* input_path);
+} // namespace scorepy

--- a/src/scorepy/pythonHelpers.cpp
+++ b/src/scorepy/pythonHelpers.cpp
@@ -1,4 +1,5 @@
 #include "pythonHelpers.hpp"
+#include "pathUtils.hpp"
 #include <stdlib.h>
 
 namespace scorepy
@@ -25,8 +26,7 @@ std::string get_file_name(const PyFrameObject& frame)
     {
         return "None";
     }
-    char actual_path[PATH_MAX];
-    const char* full_file_name = PyUnicode_AsUTF8(filename);
-    return full_file_name ? full_file_name : "ErrorPath";
+    const std::string full_file_name = abspath(PyUnicode_AsUTF8(filename));
+    return !full_file_name.empty() ? full_file_name : "ErrorPath";
 }
 } // namespace scorepy

--- a/test/test_pathUtils.cpp
+++ b/test/test_pathUtils.cpp
@@ -1,0 +1,52 @@
+#include "scorepy/pathUtils.hpp"
+#include <iostream>
+#include <stdexcept>
+
+#define TEST(condition)                                                                            \
+    if (!(condition))                                                                              \
+    throw std::runtime_error(std::string("Test ") + #condition + " failed at " + __FILE__ + ":" +  \
+                             std::to_string(__LINE__))
+
+int main()
+{
+    using scorepy::abspath;
+    // Multiple slashes at start collapsed to 1
+    TEST(abspath("/abc") == "/abc");
+    TEST(abspath("//abc") == "//abc");
+    TEST(abspath("///abc") == "/abc");
+    TEST(abspath("////abc") == "/abc");
+    // Trailing slashes and multiple slashes removed
+    TEST(abspath("/abc/") == "/abc");
+    TEST(abspath("/abc//") == "/abc");
+    TEST(abspath("/abc//de") == "/abc/de");
+    TEST(abspath("/abc//de///fg") == "/abc/de/fg");
+    TEST(abspath("/abc//de///fg/") == "/abc/de/fg");
+    TEST(abspath("/abc//de///fg////") == "/abc/de/fg");
+    TEST(abspath("//abc/") == "//abc");
+    TEST(abspath("//abc//") == "//abc");
+    TEST(abspath("//abc//de") == "//abc/de");
+    TEST(abspath("//abc//de///fg") == "//abc/de/fg");
+    TEST(abspath("//abc//de///fg/") == "//abc/de/fg");
+    TEST(abspath("//abc//de///fg////") == "//abc/de/fg");
+    // Single dots removed
+    TEST(abspath("/./abc/./defgh/./ijkl/.") == "/abc/defgh/ijkl");
+    TEST(abspath("/./abc././def.gh/./ijkl././.mn/.") == "/abc./def.gh/ijkl./.mn");
+    // Going up 1 level removes prior folder
+    TEST(abspath("/abc/..") == "/");
+    TEST(abspath("//abc/..") == "//");
+    TEST(abspath("///abc/..") == "/");
+    TEST(abspath("/abc/../de") == "/de");
+    TEST(abspath("//abc/../de") == "//de");
+    TEST(abspath("///abc/../de") == "/de");
+    TEST(abspath("/abc/de/../fg") == "/abc/fg");
+    TEST(abspath("/abc/de/../../fg") == "/fg");
+    TEST(abspath("/abc/de../../fg") == "/abc/fg");
+    TEST(abspath("/abc../de/../fg") == "/abc../fg");
+    // Going up from root does nothing
+    TEST(abspath("/../ab") == "/ab");
+    TEST(abspath("//../ab") == "//ab");
+    TEST(abspath("///../ab") == "/ab");
+    TEST(abspath("/abc/defgh/../../ijkl") == "/ijkl");
+    TEST(abspath("//abc/defgh/../../ijkl") == "//ijkl");
+    TEST(abspath("///abc/defgh/../../ijkl") == "/ijkl");
+}


### PR DESCRIPTION
This makes sure that the fast C++ implementation behaves similar to the Python implementation by expanding and normalizing paths.
Tests added to ensure correct implementation.