### PR TITLE
Add --verbose switch and fix some style issues and typos

### DIFF
--- a/scorep/__main__.py
+++ b/scorep/__main__.py
@@ -3,10 +3,11 @@ import sys
 
 import scorep.instrumenter
 import scorep.subsystem
+from scorep.helper import print_err
 
 
 def _err_exit(msg):
-    sys.stderr.write("%s: %s\n" % ("scorep", msg))
+    print_err("scorep: " + msg)
     sys.exit(1)
 
 
@@ -19,6 +20,7 @@ def scorep_main(argv=None):
     parse_scorep_commands = True
 
     keep_files = False
+    verbose = False
     no_default_threads = False
     no_default_compiler = False
     no_instrumenter = False
@@ -26,10 +28,14 @@ def scorep_main(argv=None):
 
     for elem in argv[1:]:
         if parse_scorep_commands:
-            if elem == "--mpi":
+            if elem == "--":
+                parse_scorep_commands = False
+            elif elem == "--mpi":
                 scorep_config.append("--mpp=mpi")
             elif elem == "--keep-files":
                 keep_files = True
+            elif elem == "--verbose" or elem == '-v':
+                verbose = True
             elif "--thread=" in elem:
                 scorep_config.append(elem)
                 no_default_threads = True
@@ -61,7 +67,7 @@ def scorep_main(argv=None):
         _err_exit("Did not find a script to run")
 
     if os.environ.get("SCOREP_PYTHON_BINDINGS_INITIALISED") != "true":
-        scorep.subsystem.init_environment(scorep_config, keep_files)
+        scorep.subsystem.init_environment(scorep_config, keep_files, verbose)
         os.environ["SCOREP_PYTHON_BINDINGS_INITIALISED"] = "true"
         """
         python -m starts the module as skript. i.e. sys.argv will loke like:

--- a/scorep/helper.py
+++ b/scorep/helper.py
@@ -4,11 +4,15 @@ import os
 import re
 
 
+def print_err(*args, **kwargs):
+    """Print to stderr"""
+    print(*args, file=sys.stderr, **kwargs)
+
+
 def call(arguments):
     """
     return a triple with (returncode, stdout, stderr) from the call to subprocess
     """
-    result = ()
     if sys.version_info > (3, 5):
         out = subprocess.run(
             arguments,
@@ -74,15 +78,15 @@ def add_to_ld_library_path(path):
         os.environ["LD_LIBRARY_PATH"] = ':'.join([path] + library_paths)
 
 
-def generate_compile_deps(config=[]):
+def generate_compile_deps(config):
     """
     Generates the data needed for compilation.
     """
 
-    scorep_config = ["scorep-config"] + config + ["--user"]
+    scorep_config = ["scorep-config"] + config
 
-    (retrun_code, _, _) = call(scorep_config)
-    if retrun_code != 0:
+    (return_code, _, _) = call(scorep_config)
+    if return_code != 0:
         raise ValueError(
             "given config {} is not supported".format(config))
 

--- a/scorep/helper.py
+++ b/scorep/helper.py
@@ -4,9 +4,9 @@ import os
 import re
 
 
-def print_err(*args, **kwargs):
+def print_err(*args):
     """Print to stderr"""
-    print(*args, file=sys.stderr, **kwargs)
+    sys.stderr.write(' '.join(map(str, args)) + '\n')
 
 
 def call(arguments):

--- a/scorep/subsystem.py
+++ b/scorep/subsystem.py
@@ -120,6 +120,8 @@ def init_environment(scorep_config, keep_files=False, verbose=False):
     if verbose:
         _print_info("Score-P config: %s" % scorep_config)
 
+    old_env = os.environ.copy()
+
     subsystem_lib_name, temp_dir = generate(scorep_config, keep_files)
     scorep_ld_preload = generate_ld_preload(scorep_config)
 
@@ -136,7 +138,12 @@ def init_environment(scorep_config, keep_files=False, verbose=False):
 
     if verbose:
         for var in ("LD_LIBRARY_PATH", "LD_PRELOAD"):
-            _print_info("%s='%s'" % (var, os.environ[var]))
+            # Shorten the setting to e.g.: FOO=new:$FOO
+            old_val = old_env.get(var)
+            new_val = os.environ[var]
+            if old_val:
+                new_val = new_val.replace(old_val, '$' + var)
+            _print_info('%s="%s"' % (var, new_val))
 
 
 def reset_preload():

--- a/scorep/subsystem.py
+++ b/scorep/subsystem.py
@@ -1,10 +1,15 @@
 import os
-import sys
 import distutils.ccompiler
 import tempfile
 import shutil
 
 import scorep.helper
+from scorep.helper import print_err
+
+
+def _print_info(msg):
+    """Print an info message with a prefix"""
+    print_err("scorep: " + msg)
 
 
 def generate_subsystem_lib_name():
@@ -24,9 +29,8 @@ def generate_ld_preload(scorep_config):
     @return ld_preload string which needs to be passed to LD_PRELOAD
     """
 
-    (_, preload, _) = scorep.helper.call(
-        ["scorep-config"] + scorep_config + ["--user", "--preload-libs"])
-    return preload
+    (_, preload, _) = scorep.helper.call(["scorep-config"] + scorep_config + ["--preload-libs"])
+    return preload.strip()
 
 
 def generate_subsystem_code(config=[]):
@@ -36,8 +40,8 @@ def generate_subsystem_code(config=[]):
 
     scorep_config = ["scorep-config"] + config + ["--user"]
 
-    (retrun_code, _, _) = scorep.helper.call(scorep_config)
-    if retrun_code != 0:
+    (return_code, _, _) = scorep.helper.call(scorep_config)
+    if return_code != 0:
         raise ValueError(
             "given config {} is not supported".format(scorep_config))
     (_, scorep_adapter_init, _) = scorep.helper.call(
@@ -75,9 +79,7 @@ def generate(scorep_config, keep_files=False):
 
     temp_dir = tempfile.mkdtemp(prefix="scorep.")
     if keep_files:
-        sys.stderr.write(
-            "Score-P files are keept at: {}\n".format(temp_dir))
-        sys.stderr.flush()
+        _print_info("Score-P files are kept at: " + temp_dir)
 
     with open(temp_dir + "/scorep_init.c", "w") as f:
         f.write(scorep_adapter_init)
@@ -99,34 +101,42 @@ def generate(scorep_config, keep_files=False):
     return(subsystem_lib_name, temp_dir)
 
 
-def init_environment(scorep_config=[], keep_files=False):
+def init_environment(scorep_config, keep_files=False, verbose=False):
     """
-    Set the inital needed environmet variables, to get everythin up an running.
-    As a few variables interact with LD env vars, the programms needs to be restarted after this.
+    Set the inital needed environment variables, to get everything up an running.
+    As a few variables interact with LD env vars, the program needs to be restarted after this.
 
     @param scorep_config configuration flags for score-p
     @param keep_files whether to keep the generated files, or not.
+    @param verbose Set to True to output information about config used and environment variables set.
     """
 
     if "libscorep" in os.environ.get("LD_PRELOAD", ""):
-        raise RuntimeError(
-            "Score-P is already loaded. This should not happen at this point")
+        raise RuntimeError("Score-P is already loaded. This should not happen at this point")
 
-    subsystem_lib_name, temp_dir = scorep.subsystem.generate(
-        scorep_config, keep_files)
+    if "--user" not in scorep_config:
+        scorep_config.append("--user")
+
+    if verbose:
+        _print_info("Score-P config: %s" % scorep_config)
+
+    subsystem_lib_name, temp_dir = generate(scorep_config, keep_files)
     scorep_ld_preload = generate_ld_preload(scorep_config)
 
     scorep.helper.add_to_ld_library_path(temp_dir)
 
     preload_str = scorep_ld_preload + " " + subsystem_lib_name
-    if "LD_PRELOAD" in os.environ:
-        sys.stderr.write(
-            "LD_PRELOAD is already specified. If Score-P is already loaded this might lead to errors.")
+    if os.environ.get("LD_PRELOAD"):
+        print_err("LD_PRELOAD is already specified. If Score-P is already loaded this might lead to errors.")
         preload_str = os.environ["LD_PRELOAD"] + " " + preload_str
         os.environ["SCOREP_LD_PRELOAD_BACKUP"] = os.environ["LD_PRELOAD"]
     else:
         os.environ["SCOREP_LD_PRELOAD_BACKUP"] = ""
     os.environ["LD_PRELOAD"] = preload_str
+
+    if verbose:
+        for var in ("LD_LIBRARY_PATH", "LD_PRELOAD"):
+            _print_info("%s='%s'" % (var, os.environ[var]))
 
 
 def reset_preload():

--- a/scorep/subsystem.py
+++ b/scorep/subsystem.py
@@ -33,12 +33,12 @@ def generate_ld_preload(scorep_config):
     return preload.strip()
 
 
-def generate_subsystem_code(config=[]):
+def generate_subsystem_code(config):
     """
     Generates the data needed to be preloaded.
     """
 
-    scorep_config = ["scorep-config"] + config + ["--user"]
+    scorep_config = ["scorep-config"] + config
 
     (return_code, _, _) = scorep.helper.call(scorep_config)
     if return_code != 0:

--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,12 @@ check_compiler = scorep.helper.get_scorep_config("C99 compiler used:")
 if "gcc" in check_compiler:
     gcc_plugin = scorep.helper.get_scorep_config("GCC plug-in support:")
     if not ("yes" in gcc_plugin):
-        raise RuntimeError(
-            "Score-P uses GCC but is not build with GCC Compiler Plugin. GCC plug-in support is:\n{}".format(gcc_plugin))
+        raise RuntimeError("Score-P uses GCC but is not build with GCC Compiler Plugin. "
+                           "GCC plug-in support is:\n{}".format(gcc_plugin))
 
 
 cmodules = []
-(include, _, _, _, _) = scorep.helper.generate_compile_deps()
+(include, _, _, _, _) = scorep.helper.generate_compile_deps([])
 src_folder = os.path.abspath('src')
 include += [src_folder]
 sources = ['src/methods.cpp', 'src/scorep_bindings.cpp', 'src/scorepy/events.cpp']
@@ -42,7 +42,7 @@ cmodules.append(Extension('scorep._bindings',
 setup(
     name='scorep',
     version=scorep._version.__version__,
-    description='This is a scorep tracing package for python',
+    description='This is a Score-P tracing package for python',
     author='Andreas Gocht',
     author_email='andreas.gocht@tu-dresden.de',
     url='https://github.com/score-p/scorep_binding_python',


### PR DESCRIPTION
Calling `python -m scorep --verbose ...` will print out the effective Score-P config used and the LD_* variables set so the program can also be started manually for testing purposes.
Most useful for use with --keep-files

Example: 
```
python -m scorep --noinstrumenter --cuda --verbose --keep-files exit-region-same-but-not.py
scorep: Score-P config: ['--cuda', '--thread=pthread', '--compiler', '--user']
scorep: Score-P files are kept at: /tmp/scorep.b0if5w3_
scorep: LD_LIBRARY_PATH="/tmp/scorep.b0if5w3_:$LD_LIBRARY_PATH"
scorep: LD_PRELOAD="/sw/installed/Score-P/6.0-gompic-2019b/lib/libscorep_adapter_compiler_event.so /sw/installed/Score-P/6.0-gompic-2019b/lib/libscorep_adapter_user_event.so /sw/installed/Score-P/6.0-gompic-2019b/lib/libscorep_adapter_opencl_event_linktime.so /sw/installed/Score-P/6.0-gompic-2019b/lib/libscorep_adapter_pthread_event.so /sw/installed/Score-P/6.0-gompic-2019b/lib/libscorep_measurement.so /sw/installed/Score-P/6.0-gompic-2019b/lib/libscorep_constructor.so libscorep_init_subsystem-3.7.so"
```