### PR TITLE
Add a decorator for instrumenter handling

### DIFF
--- a/scorep/subsystem.py
+++ b/scorep/subsystem.py
@@ -128,7 +128,9 @@ def init_environment(scorep_config, keep_files=False, verbose=False):
     if not os.access(temp_dir + "/" + subsystem_lib_name, os.X_OK):
         clean_up(keep_files=keep_files)
         raise RuntimeError(
-            "The Score-P Subsystem Library at {} cannot be executed. Cleaning up.".format(temp_dir + "/" + subsystem_lib_name))
+            "The Score-P Subsystem Library at {} cannot be executed. Changing $TMP might help. "
+            "Directory erased, use --keep-files to inspect the situation.".format(
+                temp_dir + "/" + subsystem_lib_name))
 
     scorep.helper.add_to_ld_library_path(temp_dir)
 

--- a/scorep/subsystem.py
+++ b/scorep/subsystem.py
@@ -125,6 +125,11 @@ def init_environment(scorep_config, keep_files=False, verbose=False):
     subsystem_lib_name, temp_dir = generate(scorep_config, keep_files)
     scorep_ld_preload = generate_ld_preload(scorep_config)
 
+    if not os.access(temp_dir + "/" + subsystem_lib_name, os.X_OK):
+        clean_up(keep_files=keep_files)
+        raise RuntimeError(
+            "The Score-P Subsystem Library at {} cannot be executed. Cleaning up.".format(temp_dir + "/" + subsystem_lib_name))
+
     scorep.helper.add_to_ld_library_path(temp_dir)
 
     preload_str = scorep_ld_preload + " " + subsystem_lib_name

--- a/test/cases/user_instrumentation.py
+++ b/test/cases/user_instrumentation.py
@@ -4,9 +4,16 @@ import instrumentation2
 
 def foo():
     print("hello world")
-    instrumentation2.baz()
     instrumentation2.bar()
+
+
+@scorep.instrumenter.enable()
+def foo2():
+    print("hello world2")
+    instrumentation2.baz()
 
 
 with scorep.instrumenter.enable():
     foo()
+
+foo2()

--- a/test/test_scorep.py
+++ b/test/test_scorep.py
@@ -254,13 +254,15 @@ def test_user_instrumentation(scorep_env, instrumenter):
     )
 
     assert std_err == ""
-    assert std_out == "hello world\nbaz\nbar\n"
+    assert std_out == "hello world\nbar\nhello world2\nbaz"
 
     std_out, std_err = call(["otf2-print", trace_path])
 
     assert std_err == ""
     assert re.search('ENTER[ ]*[0-9 ]*[0-9 ]*Region: "__main__:foo"', std_out)
     assert re.search('LEAVE[ ]*[0-9 ]*[0-9 ]*Region: "__main__:foo"', std_out)
+    assert re.search('ENTER[ ]*[0-9 ]*[0-9 ]*Region: "__main__:foo2"', std_out)
+    assert re.search('LEAVE[ ]*[0-9 ]*[0-9 ]*Region: "__main__:foo2"', std_out)
 
 
 @foreach_instrumenter

--- a/test/test_scorep.py
+++ b/test/test_scorep.py
@@ -254,7 +254,7 @@ def test_user_instrumentation(scorep_env, instrumenter):
     )
 
     assert std_err == ""
-    assert std_out == "hello world\nbar\nhello world2\nbaz"
+    assert std_out == "hello world\nbar\nhello world2\nbaz\n"
 
     std_out, std_err = call(["otf2-print", trace_path])
 
@@ -263,6 +263,10 @@ def test_user_instrumentation(scorep_env, instrumenter):
     assert re.search('LEAVE[ ]*[0-9 ]*[0-9 ]*Region: "__main__:foo"', std_out)
     assert re.search('ENTER[ ]*[0-9 ]*[0-9 ]*Region: "__main__:foo2"', std_out)
     assert re.search('LEAVE[ ]*[0-9 ]*[0-9 ]*Region: "__main__:foo2"', std_out)
+    assert re.search('ENTER[ ]*[0-9 ]*[0-9 ]*Region: "instrumentation2:bar"', std_out)
+    assert re.search('LEAVE[ ]*[0-9 ]*[0-9 ]*Region: "instrumentation2:bar"', std_out)
+    assert re.search('ENTER[ ]*[0-9 ]*[0-9 ]*Region: "instrumentation2:baz"', std_out)
+    assert re.search('LEAVE[ ]*[0-9 ]*[0-9 ]*Region: "instrumentation2:baz"', std_out)
 
 
 @foreach_instrumenter


### PR DESCRIPTION
Adds a decorator, such that `foo2` is instrumented similar to `foo`

```
def foo():
    print("hello world")
    instrumentation2.bar()


@scorep.instrumenter.enable()
def foo2():
    print("hello world2")
    instrumentation2.baz()


with scorep.instrumenter.enable():
    foo()

foo2()
```