### PR TITLE
Manual finalize and reregistering of atexit handler

### DIFF
--- a/src/methods.cpp
+++ b/src/methods.cpp
@@ -12,6 +12,9 @@ extern "C"
 
     extern const char* SCOREP_GetExperimentDirName(void);
 
+    extern void SCOREP_RegisterExitHandler(void);
+    extern void SCOREP_FinalizeMeasurement(void);
+
     static PyObject* enable_recording(PyObject* self, PyObject* args)
     {
         SCOREP_User_EnableRecording();
@@ -191,6 +194,18 @@ extern "C"
         return PyUnicode_FromString(scorepy::abspath(path).c_str());
     }
 
+    static PyObject* manual_finalize(PyObject* self, PyObject* args)
+    {
+        SCOREP_FinalizeMeasurement();
+        Py_RETURN_NONE;
+    }
+
+    static PyObject* reregister_exit_handler(PyObject* self, PyObject* args)
+    {
+        SCOREP_RegisterExitHandler();
+        Py_RETURN_NONE;
+    }
+
     static PyMethodDef ScorePMethods[] = {
         { "region_begin", region_begin, METH_VARARGS, "enter a region." },
         { "region_end", region_end, METH_VARARGS, "exit a region." },
@@ -206,6 +221,9 @@ extern "C"
         { "get_experiment_dir_name", get_experiment_dir_name, METH_VARARGS,
           "Get the Score-P experiment dir." },
         { "abspath", abspath, METH_VARARGS, "Estimates the absolute Path." },
+        { "manual_finalize", manual_finalize, METH_VARARGS, "triggers a finalize" },
+        { "reregister_exit_handler", reregister_exit_handler, METH_VARARGS,
+          "register an new atexit handler" },
         { NULL, NULL, 0, NULL } /* Sentinel */
     };
 }

--- a/src/methods.cpp
+++ b/src/methods.cpp
@@ -194,7 +194,7 @@ extern "C"
         return PyUnicode_FromString(scorepy::abspath(path).c_str());
     }
 
-    static PyObject* manual_finalize(PyObject* self, PyObject* args)
+    static PyObject* force_finalize(PyObject* self, PyObject* args)
     {
         SCOREP_FinalizeMeasurement();
         Py_RETURN_NONE;
@@ -221,7 +221,7 @@ extern "C"
         { "get_experiment_dir_name", get_experiment_dir_name, METH_VARARGS,
           "Get the Score-P experiment dir." },
         { "abspath", abspath, METH_VARARGS, "Estimates the absolute Path." },
-        { "manual_finalize", manual_finalize, METH_VARARGS, "triggers a finalize" },
+        { "force_finalize", force_finalize, METH_VARARGS, "triggers a finalize" },
         { "reregister_exit_handler", reregister_exit_handler, METH_VARARGS,
           "register an new atexit handler" },
         { NULL, NULL, 0, NULL } /* Sentinel */


### PR DESCRIPTION
This PR adds 2 calls to Score-P into the backend to force Score-P to finalize the trace and to reregister its atexit handler before the one of your application (e.g. if your application removed the one created by Score-P previously). 
A manual finalize is needed if your application does not a clean termination (e.g. crash) but you need to get a trace which would be discarded without a finalize in Score-P. By calling `manual_finalize` at the last position your application is working as expected the trace will be written and any further regions will be ignored.

