### PR TITLE
Catch code object destruction

### DIFF
--- a/src/scorepy/compat.hpp
+++ b/src/scorepy/compat.hpp
@@ -36,5 +36,8 @@ namespace compat
 
     using PyCodeObject = PyCodeObject;
 
+    using destructor = destructor;
+    using code_dealloc = std::add_pointer<void(PyCodeObject*)>::type; // void(*)(PyCodeObject*)
+
 } // namespace compat
 } // namespace scorepy

--- a/src/scorepy/events.cpp
+++ b/src/scorepy/events.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <array>
 #include <iostream>
+#include <mutex>
 
 #include <Python.h>
 
@@ -14,6 +15,42 @@ namespace scorepy
 std::unordered_map<compat::PyCodeObject*, region_handle> regions;
 static std::unordered_map<std::string, region_handle> user_regions;
 static std::unordered_map<std::string, region_handle> rewind_regions;
+
+static compat::code_dealloc python_code_dealloc = nullptr;
+
+/**
+ * @brief our code deallocator, which removes code objects form the regions map, after calling the
+ * original code object.
+ *
+ * @param co code object to remove
+ */
+void code_dealloc(PyCodeObject* co)
+{
+    python_code_dealloc(co);
+    regions.erase(co);
+}
+
+/**
+ * @brief We need to make sure, that the we register our own dealloc function, so we can handle the
+ * deleteion of code_objects in our code.
+ *
+ */
+struct RegisterCodeDealloc
+{
+    RegisterCodeDealloc()
+    {
+        if (!python_code_dealloc)
+        {
+            python_code_dealloc = reinterpret_cast<compat::code_dealloc>(PyCode_Type.tp_dealloc);
+            PyCode_Type.tp_dealloc = reinterpret_cast<compat::destructor>(code_dealloc);
+        }
+        else
+        {
+            std::cerr << "WARNING: Score-P Python's code_dealloc is alredy registerd!" << std::endl;
+        }
+    }
+};
+static RegisterCodeDealloc register_dealloc;
 
 // Used for regions, that have an identifier, aka a code object id. (instrumenter regions and
 // some decorated regions)

--- a/src/scorepy/events.cpp
+++ b/src/scorepy/events.cpp
@@ -1,7 +1,5 @@
 #include <algorithm>
 #include <array>
-#include <iostream>
-#include <mutex>
 
 #include <Python.h>
 

--- a/src/scorepy/events.cpp
+++ b/src/scorepy/events.cpp
@@ -50,7 +50,11 @@ struct RegisterCodeDealloc
         }
     }
 };
+
+// we only need this on CPython.
+#ifndef PYPY_VERSION
 static RegisterCodeDealloc register_dealloc;
+#endif
 
 // Used for regions, that have an identifier, aka a code object id. (instrumenter regions and
 // some decorated regions)


### PR DESCRIPTION
This PR registers our callback function for destroying a PyCodeObject. So we can delete the entry to this specific Object, and add a new region for this object later on. The original callback is called from our callback function.