### PR TITLE
correct C99 detection for Score-P 8 (credits @rtschueter)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,10 @@ if not ("shared=yes" in link_mode):
     )
 
 check_compiler = scorep.helper.get_scorep_config("C99 compiler used:")
+if check_compiler is None:
+    check_compiler = scorep.helper.get_scorep_config("C99 compiler:")
+if check_compiler is None:
+    raise RuntimeError("Can not parse the C99 compiler, aborting!")
 if "gcc" in check_compiler:
     gcc_plugin = scorep.helper.get_scorep_config("GCC plug-in support:")
     if not ("yes" in gcc_plugin):


### PR DESCRIPTION
This PR extends the C99 Compiler detection and adds an exception if it cannot be found!
This is needed for Score-P 8.

Credits @rtschueter for finding this error and providing a solution.