### PR TITLE
Finalise Score-P 8.0 Support

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,9 +18,6 @@ jobs:
     - name: Check Version
       run: test ${{ github.event.release.tag_name }} = `python -c "import scorep._version; print('v'+scorep._version.__version__)"`
 
-    - name: Install MPI
-      run: sudo apt-get -y install openmpi-common openmpi-bin libopenmpi-dev
-
     - name: Add Score-P repo
       run: sudo add-apt-repository ppa:andreasgocht/scorep
     

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
 
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Check Version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,12 +17,15 @@ jobs:
         python-version: 3.8
     - name: Check Version
       run: test ${{ github.event.release.tag_name }} = `python -c "import scorep._version; print('v'+scorep._version.__version__)"`
-    
+
+    - name: Install MPI
+      run: sudo apt-get -y install openmpi-common openmpi-bin libopenmpi-dev
+
     - name: Add Score-P repo
       run: sudo add-apt-repository ppa:andreasgocht/scorep
     
     - name: Install Score-P      
-      run: sudo apt install scorep
+      run: sudo apt-get -y install scorep
 
     - name: Setup environment
       run: echo "$HOME/scorep/bin" >> $GITHUB_PATH

--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 
 jobs:
   Cpp:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - name: Formatting
@@ -13,10 +13,10 @@ jobs:
         clangFormatVersion: 9
 
   Python:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install Python packages

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -19,11 +19,14 @@ jobs:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip
 
+    - name: Install MPI
+      run: sudo apt-get -y install openmpi-common openmpi-bin libopenmpi-dev
+
     - name: Add Score-P repo
       run: sudo add-apt-repository ppa:andreasgocht/scorep
     
     - name: Install Score-P      
-      run: sudo apt install scorep
+      run: sudo apt-get -y install scorep
 
     - name: Setup environment
       run: echo "$HOME/scorep/bin" >> $GITHUB_PATH

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -19,9 +19,6 @@ jobs:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip
 
-    - name: Install MPI
-      run: sudo apt-get -y install openmpi-common openmpi-bin libopenmpi-dev
-
     - name: Add Score-P repo
       run: sudo add-apt-repository ppa:andreasgocht/scorep
     

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -3,6 +3,8 @@ on: [push, pull_request, workflow_dispatch]
 
 env:
   SCOREP_TIMER: clock_gettime # tsc causes warnings
+  RDMAV_FORK_SAFE: 
+  IBV_FORK_SAFE: 
 
 jobs:
   build:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", 'pypy-2.7', 'pypy-3.6', 'pypy-3.7', 'pypy-3.8']
+        python: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", 'pypy-2.7', 'pypy-3.6', 'pypy-3.7', 'pypy-3.8']
       fail-fast: false
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/cache@v1
+    - uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip
@@ -28,7 +28,7 @@ jobs:
     - name: Setup environment
       run: echo "$HOME/scorep/bin" >> $GITHUB_PATH
     - name: set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{matrix.python}}
         architecture: x64

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["2.7", "3.5", "3.6", "3.7", "3.8", "3.9", "3.10", "3.11", 'pypy-2.7', 'pypy-3.6', 'pypy-3.7', 'pypy-3.8']
+        python: ["2.7", "3.7", "3.8", "3.9", "3.10", "3.11", 'pypy-2.7', 'pypy-3.6', 'pypy-3.7', 'pypy-3.8']
       fail-fast: false
 
     steps:

--- a/test/test_scorep.py
+++ b/test/test_scorep.py
@@ -265,7 +265,7 @@ def test_mpi(scorep_env, instrumenter):
         env=scorep_env,
     )
 
-    assert re.search(r"\[Score-P\] [\w/.: ]*MPI_THREAD_FUNNELED", std_err)
+    assert re.search(r"\[Score-P\] [\w/.: ]*MPI_THREAD_\(SERIALIZED\|MULTIPLE\) ", std_err)
     assert "[00] [0. 1. 2. 3. 4.]\n" in std_out
     assert "[01] [0. 1. 2. 3. 4.]\n" in std_out
     assert "bar\n" in std_out


### PR DESCRIPTION
These are mostly CI and Test fixes. I also added python 3.11 to the tests, but this is obviously broken (see https://github.com/score-p/scorep_binding_python/issues/153 ).

Moreover, there is a bug with python2.7. However, it works on my local machine, and python2.7 has been out of support for over two years now. I, therefore, choose to ignore it for now.