### PR TITLE
Support Python 3.11 

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["2.7", "3.7", "3.8", "3.9", "3.10", "3.11", 'pypy-2.7', 'pypy-3.6', 'pypy-3.7', 'pypy-3.8']
+        python: ["2.7", "3.7", "3.8", "3.9", "3.10", "3.11", 'pypy-2.7', 'pypy-3.6', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
       fail-fast: false
 
     steps:

--- a/src/scorepy/cInstrumenter.cpp
+++ b/src/scorepy/cInstrumenter.cpp
@@ -131,6 +131,9 @@ bool CInstrumenter::on_event(PyFrameObject& frame, int what, PyObject*)
                 region_begin(name, module_name, file_name, line_number, code);
             }
         }
+#if PY_VERSION_HEX >= 0x030b00f0 // python 3.11.0
+        Py_DECREF(code);
+#endif
         break;
     }
     case PyTrace_RETURN:
@@ -151,6 +154,9 @@ bool CInstrumenter::on_event(PyFrameObject& frame, int what, PyObject*)
                 region_end(name, module_name, code);
             }
         }
+#if PY_VERSION_HEX >= 0x030b00f0 // python 3.11.0
+        Py_DECREF(code);
+#endif
         break;
     }
     }

--- a/src/scorepy/cInstrumenter.cpp
+++ b/src/scorepy/cInstrumenter.cpp
@@ -114,7 +114,11 @@ bool CInstrumenter::on_event(PyFrameObject& frame, int what, PyObject*)
     {
     case PyTrace_CALL:
     {
+#if PY_VERSION_HEX < 0x030b00f0 // python 3.11.0
         PyCodeObject* code = frame.f_code;
+#else
+        PyCodeObject* code = PyFrame_GetCode(&frame);
+#endif
         bool success = try_region_begin(code);
         if (!success)
         {
@@ -131,7 +135,11 @@ bool CInstrumenter::on_event(PyFrameObject& frame, int what, PyObject*)
     }
     case PyTrace_RETURN:
     {
+#if PY_VERSION_HEX < 0x030b00f0 // python 3.11.0
         PyCodeObject* code = frame.f_code;
+#else
+        PyCodeObject* code = PyFrame_GetCode(&frame);
+#endif
         bool success = try_region_end(code);
         if (!success)
         {

--- a/src/scorepy/cInstrumenter.cpp
+++ b/src/scorepy/cInstrumenter.cpp
@@ -114,7 +114,7 @@ bool CInstrumenter::on_event(PyFrameObject& frame, int what, PyObject*)
     {
     case PyTrace_CALL:
     {
-#if PY_VERSION_HEX < 0x030b00f0 // python 3.11.0
+#if PY_VERSION_HEX < 0x030b00a0 // python 3.11.0
         PyCodeObject* code = frame.f_code;
 #else
         PyCodeObject* code = PyFrame_GetCode(&frame);
@@ -131,14 +131,14 @@ bool CInstrumenter::on_event(PyFrameObject& frame, int what, PyObject*)
                 region_begin(name, module_name, file_name, line_number, code);
             }
         }
-#if PY_VERSION_HEX >= 0x030b00f0 // python 3.11.0
+#if PY_VERSION_HEX >= 0x030b00a0 // python 3.11.0
         Py_DECREF(code);
 #endif
         break;
     }
     case PyTrace_RETURN:
     {
-#if PY_VERSION_HEX < 0x030b00f0 // python 3.11.0
+#if PY_VERSION_HEX < 0x030b00a0 // python 3.11.0
         PyCodeObject* code = frame.f_code;
 #else
         PyCodeObject* code = PyFrame_GetCode(&frame);
@@ -154,7 +154,7 @@ bool CInstrumenter::on_event(PyFrameObject& frame, int what, PyObject*)
                 region_end(name, module_name, code);
             }
         }
-#if PY_VERSION_HEX >= 0x030b00f0 // python 3.11.0
+#if PY_VERSION_HEX >= 0x030b00a0 // python 3.11.0
         Py_DECREF(code);
 #endif
         break;

--- a/src/scorepy/pythonHelpers.cpp
+++ b/src/scorepy/pythonHelpers.cpp
@@ -8,7 +8,7 @@ namespace scorepy
 {
 std::string_view get_module_name(PyFrameObject& frame)
 {
-#if PY_VERSION_HEX < 0x030b00f0 // python 3.11.0
+#if PY_VERSION_HEX < 0x030b00a0 // python 3.11.0
     PyObject* module_name = PyDict_GetItemString(frame.f_globals, "__name__");
 #else
     PyObject* globals = PyFrame_GetGlobals(&frame);
@@ -18,7 +18,7 @@ std::string_view get_module_name(PyFrameObject& frame)
     if (module_name)
         return compat::get_string_as_utf_8(module_name);
 
-#if PY_VERSION_HEX < 0x030b00f0 // python 3.11.0
+#if PY_VERSION_HEX < 0x030b00a0 // python 3.11.0
     PyCodeObject* code = frame.f_code;
 #else
     PyCodeObject* code = PyFrame_GetCode(&frame);
@@ -27,7 +27,7 @@ std::string_view get_module_name(PyFrameObject& frame)
     // TODO: Use string_view/C-String to avoid creating 2 std::strings
     std::string_view filename = compat::get_string_as_utf_8(code->co_filename);
 
-#if PY_VERSION_HEX >= 0x030b00f0 // python 3.11.0
+#if PY_VERSION_HEX >= 0x030b00a0 // python 3.11.0
     Py_DECREF(code);
 #endif
 
@@ -39,7 +39,7 @@ std::string_view get_module_name(PyFrameObject& frame)
 
 std::string get_file_name(PyFrameObject& frame)
 {
-#if PY_VERSION_HEX < 0x030b00f0 // python 3.11.0
+#if PY_VERSION_HEX < 0x030b00a0 // python 3.11.0
     PyCodeObject* code = frame.f_code;
     PyObject* filename = code->co_filename;
 #else

--- a/src/scorepy/pythonHelpers.hpp
+++ b/src/scorepy/pythonHelpers.hpp
@@ -73,9 +73,9 @@ auto cast_to_PyFunc(TFunc* func) -> detail::ReplaceArgsToPyObject_t<TFunc>*
 
 /// Return the module name the frame belongs to.
 /// The pointer is valid for the lifetime of the frame
-std::string_view get_module_name(const PyFrameObject& frame);
+std::string_view get_module_name(PyFrameObject& frame);
 /// Return the file name the frame belongs to
-std::string get_file_name(const PyFrameObject& frame);
+std::string get_file_name(PyFrameObject& frame);
 
 // Implementation details
 namespace detail


### PR DESCRIPTION
Adds support for Python 3.11, since they changed their C-API (see #158) 

Before merging I have to take a look if calling `Py_DECREF();` is necessary.