### PR TITLE
Adapt tests to currently supported Python versions

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11", 'pypy-2.7', 'pypy-3.6', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9']
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", 'pypy-2.7', 'pypy-3.7', 'pypy-3.9', 'pypy-3.10']
       fail-fast: false
 
     steps:


### PR DESCRIPTION
- Drop Support for CPython 2.7. PyPy still supports Python 2.7.
- Drop support for CPython 3.7 and PyPy 3.7 and 3.8
- Add support for CPython 3.12 and PyPy 3.10