### PR TITLE
Ports from distutils to setuptools

### DIFF
--- a/scorep/subsystem.py
+++ b/scorep/subsystem.py
@@ -88,8 +88,9 @@ def generate(scorep_config, keep_files=False):
     # setuptools, which replaces distutils, calls uname in python < 3.9 during distutils bootstraping.
     # When LD_PRELOAD is set, this leads to preloading Score-P to uname, and crashes the later tracing.
     # To avoid this, we need to do the distutils bootstrap as late as possible.
-    import distutils.ccompiler
-    cc = distutils.ccompiler.new_compiler()
+    # Setuptools does not support ccompiler.new_compiler https://github.com/pypa/setuptools/issues/4540
+    from setuptools._distutils.ccompiler import new_compiler
+    cc = new_compiler()
 
     compiled_subsystem = cc.compile(
         [temp_dir + "/scorep_init.c"], output_dir=temp_dir)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import os
 import sys
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 import scorep.helper
 from scorep.instrumenter import has_c_instrumenter
 


### PR DESCRIPTION
In [PEP-632](https://peps.python.org/pep-0632/) `distutils` becomes deprecated and applications should be ported to `setuptools`

At the moment `setuptools` does not implement `distutils.ccompiler.new_compiler()` see https://github.com/pypa/setuptools/issues/4540

closes #139 