### PR TITLE
Draft: Remove GCC Dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ scorep is a module that allows tracing of python scripts using [Score-P](https:/
 <!-- <small><i><a href='http://ecotrust-canada.github.io/markdown-toc/'>Table of contents generated with markdown-toc</a></i></small> -->
 
 # Install
-You need at least Score-P 5.0, build with `--enable-shared` and the gcc compiler plugin.
+You need at least Score-P 5.0, build with `--enable-shared`.
 Please make sure that `scorep-config` is in your `PATH` variable.
 
 The Score-P community provides an unofficial PPA for Ubuntu LTS systems: https://launchpad.net/~score-p/+archive/ubuntu/releases .

--- a/scorep/__main__.py
+++ b/scorep/__main__.py
@@ -21,7 +21,6 @@ def scorep_main(argv=None):
 
     keep_files = False
     verbose = False
-    no_default_compiler = False
     no_instrumenter = False
     if scorep.instrumenter.has_c_instrumenter():
         instrumenter_type = "cProfile"
@@ -39,9 +38,6 @@ def scorep_main(argv=None):
                 keep_files = True
             elif elem == "--verbose" or elem == '-v':
                 verbose = True
-            elif elem == "--nocompiler":
-                scorep_config.append(elem)
-                no_default_compiler = True
             elif elem == "--nopython":
                 no_instrumenter = True
             elif elem == "--noinstrumenter":
@@ -67,9 +63,6 @@ def scorep_main(argv=None):
                 parse_scorep_commands = False
         else:
             prog_argv.append(elem)
-
-    if not no_default_compiler:
-        scorep_config.append("--compiler")
 
     if len(prog_argv) == 0:
         _err_exit("Did not find a script to run")

--- a/setup.py
+++ b/setup.py
@@ -13,20 +13,6 @@ if not ("shared=yes" in link_mode):
         'Score-P not build with "--enable-shared". Link mode is:\n{}'.format(link_mode)
     )
 
-check_compiler = scorep.helper.get_scorep_config("C99 compiler used:")
-if check_compiler is None:
-    check_compiler = scorep.helper.get_scorep_config("C99 compiler:")
-if check_compiler is None:
-    raise RuntimeError("Can not parse the C99 compiler, aborting!")
-if "gcc" in check_compiler:
-    gcc_plugin = scorep.helper.get_scorep_config("GCC plug-in support:")
-    if not ("yes" in gcc_plugin):
-        raise RuntimeError(
-            "Score-P uses GCC but is not build with GCC Compiler Plugin. "
-            "GCC plug-in support is:\n{}".format(gcc_plugin)
-        )
-
-
 install_requires= ["setuptools>=68.0.0"]
 
 cmodules = []


### PR DESCRIPTION
Fixes #177

- [x] Removes dependency for GCC plugin
- [x] Compiler instrumentation by `--compiler` is not a default anymore